### PR TITLE
Added support for FreeMarker Locale support when formatting Java 8 time objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>no.api.freemarker</groupId>
     <artifactId>freemarker-java8</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
 
     <organization>
         <name>Amedia Utvikling AS</name>
@@ -117,5 +117,28 @@
         </snapshotRepository>
 
     </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/main/java/no/api/freemarker/java8/time/DateTimeTools.java
+++ b/src/main/java/no/api/freemarker/java8/time/DateTimeTools.java
@@ -60,7 +60,7 @@ public final class DateTimeTools {
                                                             int index,
                                                             final DateTimeFormatter defaultFormatter) {
         if (list.size() > 0) {
-            return DateTimeFormatter.ofPattern(((SimpleScalar) list.get(index)).getAsString());
+            return DateTimeFormatter.ofPattern(((SimpleScalar) list.get(index)).getAsString(), Environment.getCurrentEnvironment().getLocale());
         }
         return defaultFormatter;
     }
@@ -83,7 +83,7 @@ public final class DateTimeTools {
         return DateTimeFormatter.ofPattern(
                 list.size() > index
                         ? ((SimpleScalar) list.get(index)).getAsString()
-                        : defaultPattern);
+                        : defaultPattern, Environment.getCurrentEnvironment().getLocale());
     }
 
     /**

--- a/src/main/java/no/api/freemarker/java8/time/DateTimeTools.java
+++ b/src/main/java/no/api/freemarker/java8/time/DateTimeTools.java
@@ -60,7 +60,7 @@ public final class DateTimeTools {
                                                             int index,
                                                             final DateTimeFormatter defaultFormatter) {
         if (list.size() > 0) {
-            return DateTimeFormatter.ofPattern(((SimpleScalar) list.get(index)).getAsString(), Environment.getCurrentEnvironment().getLocale());
+            return DateTimeFormatter.ofPattern(((SimpleScalar) list.get(index)).getAsString(), Environment.getCurrentEnvironment().getConfiguration().getLocale());
         }
         return defaultFormatter;
     }
@@ -83,7 +83,7 @@ public final class DateTimeTools {
         return DateTimeFormatter.ofPattern(
                 list.size() > index
                         ? ((SimpleScalar) list.get(index)).getAsString()
-                        : defaultPattern, Environment.getCurrentEnvironment().getLocale());
+                        : defaultPattern, Environment.getCurrentEnvironment().getConfiguration().getLocale());
     }
 
     /**


### PR DESCRIPTION
This makes sure `${yourLocalDate.format("d MMMM yyyy")}` works as expected in the given / configured Locale.
