### PR TITLE
Fixing bug that caused the default Locale in the JVM to be used inste…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Change Log
+
+## [freemarker-java8-1.1.4](https://github.com/amedia/freemarker-java-8/tree/freemarker-java8-1.1.4) (2016-12-15)
+[Full Changelog](https://github.com/amedia/freemarker-java-8/compare/freemarker-java8-1.1.2...freemarker-java8-1.1.4)
+
+- ZoneOffsetAdapter is not used [\#6](https://github.com/amedia/freemarker-java-8/issues/6)
+
+
+## [freemarker-java8-1.1.2](https://github.com/amedia/freemarker-java-8/tree/freemarker-java8-1.1.2) (2016-10-26)
+
+[Full Changelog](https://github.com/amedia/freemarker-java-8/compare/freemarker-java8-1.1.1...freemarker-java8-1.1.2)
+
+**Closed issues:**
+
+- wrong maven dependency  [\#5](https://github.com/amedia/freemarker-java-8/issues/5)
+- Install error [\#3](https://github.com/amedia/freemarker-java-8/issues/3)
+- Deploy to mavenCentral [\#1](https://github.com/amedia/freemarker-java-8/issues/1)
+
+**Merged pull requests:**
+
+- \#6 Fixed [\#7](https://github.com/amedia/freemarker-java-8/pull/7) ([lazee](https://github.com/lazee))
+- Update installation documentation [\#4](https://github.com/amedia/freemarker-java-8/pull/4) ([mthmulders](https://github.com/mthmulders))
+
+
+

--- a/README.adoc
+++ b/README.adoc
@@ -29,7 +29,7 @@ like this :
 ----
 
 Make sure to replace the version with the current version found in the pom.
-
+`
 ## Usage
 
 You need to tell FreeMarker about this package by adding the Java8ObjectWrapper to the FreeMarker configuration.
@@ -54,78 +54,78 @@ for formatting.
 | java.time class | methods | comment | example
 
 |Clock
-|format()
+|`format()`
 |This is a simple implementation where format just prints the toString() value of the object.
-|${myclock.format()}
+|`${myclock.format()}`
 
 |Duration
-|nano(), seconds()
+|`nano(), seconds()`
 |Gives access to the Duration values
-|${myduration.seconds}, ${myduration.nano}
+|`${myduration.seconds}, ${myduration.nano}`
 
 |Instant
-|format()
+|`format()`
 |This is a simple implementation where format just prints the toString() value of the object.
-|${myinstant.format()}
+|`${myinstant.format()}`
 
 |LocalDate
-|format(), format(pattern)
+|`format(), format(pattern)`
 |Allows you to print a LocalDate on a default pattern or by providing a custom pattern.
-|${mylocaldate.format()} or ${mylocaldate.format('yyyy MM dd')}
+|`${mylocaldate.format()}` or `${mylocaldate.format('yyyy MM dd')}`
 
 |LocalDateTime
-|format(), format(pattern)
+|`format(), format(pattern)`
 |Allows you to print a LocalDateTime on a default pattern or by providing a custom pattern.
-|${mylocaldatetime.format()} or ${mylocaldatetime.format('yyyy-MM-dd HH : mm : ss')}
+|`${mylocaldatetime.format()}` or `${mylocaldatetime.format('yyyy-MM-dd HH : mm : ss')}`
 
 |LocalTime
-|format(), format(pattern)
+|`format(), format(pattern)`
 |Allows you to print a LocalTime on a default pattern or by providing a custom pattern.
-|${mylocaltime.format()} or ${mylocaltime.format('HH : mm : ss')}
+|`${mylocaltime.format()}` or `${mylocaltime.format('HH : mm : ss')}`
 
 |MonthDay
-|format(), format(pattern)
+|`format(), format(pattern)`
 |Allows you to print a MonthDay on a default pattern or by providing a custom pattern.
-|${mymonthday.format()} or ${mymonthday.format('MM dd')}
+|`${mymonthday.format()}` or `${mymonthday.format('MM dd')}`
 
 |OffsetDateTime
-|format(), format(pattern)
+|`format(), format(pattern)`
 |Allows you to print a OffsetDateTime on a default pattern or by providing a custom pattern.
-|${myoffsetdatetime.format()} or ${myoffsetdatetime.format('yyyy MM dd HH mm ss')}
+|`${myoffsetdatetime.format()}` or `${myoffsetdatetime.format('yyyy MM dd HH mm ss')}`
 
 |OffsetTime
-|format(), format(pattern)
+|`format(), format(pattern)`
 |Allows you to print a OffsetTime on a default pattern or by providing a custom pattern.
-|${myoffsettime.format()} or ${myoffsettime.format('HH mm ss')}
+|`${myoffsettime.format()}` or `${myoffsettime.format('HH mm ss')}`
 
 |Period
-|days(), months(), years()
+|`days(), months(), years()`
 |Gives access to the values of the Period object.
-|${myperiod.days}, ${myperiod.months}, ${myperiod.years}
+|`${myperiod.days}, ${myperiod.months}, ${myperiod.years}`
 
 |Year
-|format(), format(pattern)
+|`format(), format(pattern)`
 |Allows you to print a Year on a default pattern or by providing a custom pattern.
-|${myyear.format()} or ${myyear.format('yyyy')}
+|`${myyear.format()}` or `${myyear.format('yyyy')}`
 
 |YearMonth
-|format(), format(pattern)
+|`format(), format(pattern)`
 |Allows you to print a YearMonth on a default pattern or by providing a custom pattern.
-|${myyear.format()} or ${myyear.format('yyyy MM')}
+|`${myyear.format()}` or `${myyear.format('yyyy MM')}`
 
 |ZonedDateTime
-|format(), format(pattern), format(pattern, zoneId)
+|`format(), format(pattern), format(pattern, zoneId)`
 |Allows you to print a YearMonth on a default pattern/timezone or by providing a custom pattern and timezone.
-|${myzoneddatetime.format()} or ${myzoneddatetime.format('yyyy-MM-dd Z')} or ${myzoneddatetime.format('yyyy-MM-dd Z', 'Asia/Seoul')}
+|`${myzoneddatetime.format()}` or `${myzoneddatetime.format('yyyy-MM-dd Z')}` or `${myzoneddatetime.format('yyyy-MM-dd Z', 'Asia/Seoul')}`
 
 |ZoneId
-|format(), format(textStyle), format(textstyle, locale)
+|`format(), format(textStyle), format(textstyle, locale)`
 |Prints the ZoneId display name. You can override the textstyle with one of these values
 [FULL, FULL_STANDALONE, SHORT, SHORT_STANDALONE, NARROW and NARROW_STANDALONE]. You can also override the locale, but Java only seems to have locale support for a few languages.
-|${myzoneid.format()} or ${myzoneid.format('short')} or ${myzoneid.format('short', 'no-NO')}
+|`${myzoneid.format()}` or `${myzoneid.format('short')}` or `${myzoneid.format('short', 'no-NO')}`
 
 |ZoneOffset
-|Prints the ZoneOffset display name. You can override the textstyle with one of these values
-[FULL, FULL_STANDALONE, SHORT, SHORT_STANDALONE, NARROW and NARROW_STANDALONE]. You can also override the locale, but Java only seems to have locale support for a few languages.
-|${myzoneoffset.format()} or ${myzoneoffset.format('short')} or ${myzoneoffset.format('short', 'no-NO')}
+|`format(), format(textStyle)`
+|Prints the ZoneOffset display name. You can override the textstyle with one of these values [FULL, FULL_STANDALONE, SHORT, SHORT_STANDALONE, NARROW and NARROW_STANDALONE]. You can also override the locale, but Java only seems to have locale support for a few languages.
+|${myzoneoffset.format()}` or `${myzoneoffset.format('short')}` or `${myzoneoffset.format('short', 'no-NO')}
 |===

--- a/src/main/java/no/api/freemarker/java8/time/DateTimeTools.java
+++ b/src/main/java/no/api/freemarker/java8/time/DateTimeTools.java
@@ -116,7 +116,7 @@ public final class DateTimeTools {
 
     private static Locale getLocale() {
         if (Environment.getCurrentEnvironment() != null) {
-            return Environment.getCurrentEnvironment().getConfiguration().getLocale();
+            return Environment.getCurrentEnvironment().getLocale();
         } else {
             return Locale.getDefault();
         }

--- a/src/main/java/no/api/freemarker/java8/time/DateTimeTools.java
+++ b/src/main/java/no/api/freemarker/java8/time/DateTimeTools.java
@@ -24,6 +24,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.zone.ZoneRulesException;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Helper methods and constants in use by the adapters.
@@ -60,9 +61,9 @@ public final class DateTimeTools {
                                                             int index,
                                                             final DateTimeFormatter defaultFormatter) {
         if (list.size() > 0) {
-            return DateTimeFormatter.ofPattern(((SimpleScalar) list.get(index)).getAsString());
+            return DateTimeFormatter.ofPattern(((SimpleScalar) list.get(index)).getAsString(), getLocale());
         }
-        return defaultFormatter;
+        return defaultFormatter.withLocale(getLocale());
     }
 
     /**
@@ -83,7 +84,7 @@ public final class DateTimeTools {
         return DateTimeFormatter.ofPattern(
                 list.size() > index
                         ? ((SimpleScalar) list.get(index)).getAsString()
-                        : defaultPattern);
+                        : defaultPattern, getLocale());
     }
 
     /**
@@ -111,6 +112,14 @@ public final class DateTimeTools {
             }
         }
         return zoneId;
+    }
+
+    private static Locale getLocale() {
+        if (Environment.getCurrentEnvironment() != null) {
+            return Environment.getCurrentEnvironment().getConfiguration().getLocale();
+        } else {
+            return Locale.getDefault();
+        }
     }
 
 }

--- a/src/test/java/no/api/freemarker/java8/time/DateTimeStepdefs.java
+++ b/src/test/java/no/api/freemarker/java8/time/DateTimeStepdefs.java
@@ -32,6 +32,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
+import static freemarker.template.Configuration.*;
+
 public class DateTimeStepdefs {
 
     private final Configuration configuration;
@@ -41,8 +43,8 @@ public class DateTimeStepdefs {
     private Object obj;
 
     public DateTimeStepdefs() {
-        this.configuration = new Configuration();
-        this.configuration.setObjectWrapper(new Java8ObjectWrapper(Configuration.VERSION_2_3_23));
+        this.configuration = new Configuration(VERSION_2_3_23);
+        this.configuration.setObjectWrapper(new Java8ObjectWrapper(VERSION_2_3_23));
     }
 
     @Given("^ZonedDateTime object for \"([^\"]*)\"$")

--- a/src/test/resources/no/api/freemarker/java8/time/datetime.feature
+++ b/src/test/resources/no/api/freemarker/java8/time/datetime.feature
@@ -1,206 +1,268 @@
 Feature: Test the date time functionality
 
-    Background:
-        Given an freemarker environment with locale set to "no-NO"
-        And timezone set to "Europe/Oslo"
-
     ### Clock ###
     Scenario: Test basic Clock use in template
-        Given a template "${obj}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj}"
         And Clock object for "2007-12-03T10:15:30.00Z"
         Then expect the template to return "FixedClock[2007-12-03T10:15:30Z,Europe/Oslo]"
 
     ### Duration ###
     Scenario: Test basic Duration use in template
-        Given a template "${obj}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj}"
         And Duration object for "PT15M"
         Then expect the template to return "PT15M"
 
     Scenario: Test nano Duration use in template
-        Given a template "${obj.nano}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.nano}"
         And Duration object for "PT15M"
         Then expect the template to return "0"
 
     Scenario: Test seconds Duration use in template
-        Given a template "${obj.seconds}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.seconds}"
         And Duration object for "PT15M"
         Then expect the template to return "900"
 
     ### Instant ###
     Scenario: Test basic Instant use in template
-        Given a template "${obj}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj}"
         And Instant object for "2007-12-03T10:15:30.00Z"
         Then expect the template to return "2007-12-03T10:15:30Z"
 
     ### LocalDate ###
     Scenario: Test basic LocalDate use in template
-        Given a template "${obj}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj}"
         And LocalDate object for "2007-12-03"
         Then expect the template to return "2007-12-03"
 
     Scenario: Test LocalDate use in template with custom pattern
-        Given a template "${obj.format('EEEE d MMMM yyyy')}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('EEEE d MMMM yyyy')}"
         And LocalDate object for "2007-12-03"
         Then expect the template to return "mandag 3 desember 2007"
 
     Scenario: Test LocalDate use in template with custom pattern and german locale
         Given an freemarker environment with locale set to "de-DE"
-        Given a template "${obj.format('EEEE d MMMM yyyy')}"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('EEEE d MMMM yyyy')}"
         And LocalDate object for "2007-12-03"
         Then expect the template to return "Montag 3 Dezember 2007"
 
     Scenario: Test LocalDate use in template with custom pattern and arabic locale
         Given an freemarker environment with locale set to "ar-DZ"
-        Given a template "${obj.format('EEEE d MMMM yyyy')}"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('EEEE d MMMM yyyy')}"
         And LocalDate object for "2007-12-03"
         Then expect the template to return "الاثنين 3 ديسمبر 2007"
 
     ### LocalDateTime ###
     Scenario: Test basic LocalDateTime use in template
-        Given a template "${obj}"
+        Given an freemarker environment with locale set to "ar-DZ"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj}"
         And LocalDateTime object for "2007-12-03T10:15:30"
         Then expect the template to return "2007-12-03T10:15:30"
 
     Scenario: Test basic LocalDateTime use in template with custom pattern
-        Given a template "${obj.format('EEEE d MMMM yyyy HH:mm:ss')}"
+        Given an freemarker environment with locale set to "no-No"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('EEEE d MMMM yyyy HH:mm:ss')}"
         And LocalDateTime object for "2007-12-03T10:15:30"
         Then expect the template to return "mandag 3 desember 2007 10:15:30"
 
     Scenario: Test basic LocalDateTime use in template with custom pattern and romanian locale
         Given an freemarker environment with locale set to "ro-RO"
-        Given a template "${obj.format('EEEE d MMMM yyyy HH:mm:ss')}"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('EEEE d MMMM yyyy HH:mm:ss')}"
         And LocalDateTime object for "2007-12-03T10:15:30"
         Then expect the template to return "luni 3 decembrie 2007 10:15:30"
 
     ### LocalTime ###
     Scenario: Test basic LocalTime use in template
-        Given a template "${obj}"
+        Given an freemarker environment with locale set to "no-No"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj}"
         And LocalTime object for "23:44"
         Then expect the template to return "23:44"
 
     ### MonthDay ###
     Scenario: Test basic MonthDay use in template
-        Given a template "${obj}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj}"
         And MonthDay object for "--10-14"
         Then expect the template to return "--10-14"
 
     Scenario: Test basic MonthDay use in template with custom pattern
-        Given a template "${obj.format('MMMM')}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('MMMM')}"
         And MonthDay object for "--10-14"
         Then expect the template to return "oktober"
 
     Scenario: Test basic MonthDay use in template with custom pattern and french locale
         Given an freemarker environment with locale set to "fr-FR"
-        Given a template "${obj.format('MMMM')}"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('MMMM')}"
         And MonthDay object for "--10-14"
         Then expect the template to return "octobre"
 
     ### OffsetDateTime ###
     Scenario: Test basic OffsetDateTime use in template
-        Given a template "${obj}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj}"
         And OffsetDateTime object for "2007-12-03T10:15:30+01:00"
         Then expect the template to return "2007-12-03T10:15:30+01:00"
 
     Scenario: Test basic OffsetDateTime use in template with custom pattern
-        Given a template "${obj.format('YYYY MMMM EEEE d HH:mm:ss Z')}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('YYYY MMMM EEEE d HH:mm:ss Z')}"
         And OffsetDateTime object for "2007-12-03T10:15:30+01:00"
         Then expect the template to return "2007 desember mandag 3 10:15:30 +0100"
 
     Scenario: Test basic OffsetDateTime use in template with custom pattern and finnish locale
         Given an freemarker environment with locale set to "fi-FI"
-        Given a template "${obj.format('YYYY MMMM EEEE d HH:mm:ss Z')}"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('YYYY MMMM EEEE d HH:mm:ss Z')}"
         And OffsetDateTime object for "2007-12-03T10:15:30+01:00"
         Then expect the template to return "2007 joulukuuta maanantai 3 10:15:30 +0100"
 
     ### OffsetTime ###
     Scenario: Test basic OffsetTime use in template
-        Given a template "${obj}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj}"
         And OffsetTime object for "23:44+01:00"
         Then expect the template to return "23:44+01:00"
 
     ### Period ###
     Scenario: Test basic Period use in template
-        Given a template "${obj}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj}"
         And Period object for "P1Y2M3D"
         Then expect the template to return "P1Y2M3D"
 
     Scenario: Test days Period use in template
-        Given a template "${obj.days}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.days}"
         And Period object for "P1Y2M3D"
         Then expect the template to return "3"
 
     Scenario: Test moths Period use in template
-        Given a template "${obj.months}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.months}"
         And Period object for "P1Y2M3D"
         Then expect the template to return "2"
 
     Scenario: Test years Period use in template
-        Given a template "${obj.years}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.years}"
         And Period object for "P1Y2M3D"
         Then expect the template to return "1"
 
     ### Year ###
     Scenario: Test basic Year use in template
-        Given a template "${obj}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj}"
         And Year object for "2007"
         Then expect the template to return "2007"
 
     Scenario: Test Year use in template with custom pattern
-        Given a template "${obj.format('yyyy')}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('yyyy')}"
         And Year object for "2007"
         Then expect the template to return "2007"
 
     Scenario: Test Year use in template with custom illegal pattern
-        Given a template "${obj.format('yyyy mm')}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('yyyy mm')}"
         Then expect UnsupportedTemporalTypeException
 
     ### YearMonth ###
     Scenario: Test basic YearMonth use in template
-        Given a template "${obj}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj}"
         And YearMonth object for "2007-11"
         Then expect the template to return "2007-11"
 
     Scenario: Test YearMonth use in template with custom pattern
-        Given a template "${obj.format('yyyy - MM')}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('yyyy - MM')}"
         And YearMonth object for "2007-11"
         Then expect the template to return "2007 - 11"
 
     ### ZonedDateTime ###
     Scenario: Test basic ZonedDateTime use in template.
-        Given a template "${obj}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj}"
         And ZonedDateTime object for "2007-12-03T10:15:30+01:00[Europe/Paris]"
         Then expect the template to return "2007-12-03T10:15:30+01:00[Europe/Paris]"
 
     Scenario: Test that using a preset ZonedDateTime inside a template will return the default time zone
-        Given a template "${obj.format()}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format()}"
         And ZonedDateTime object for "2007-12-03T16:15:30+07:00[Asia/Bangkok]"
         Then expect the template to return "2007-12-03T10:15:30+01:00[Europe/Oslo]"
 
     Scenario: Test that using a preset ZonedDateTime inside a template will return the default time zone when a pattern and zone id is given
-        Given a template "${obj.format('yyyy-MM-dd Z', 'Asia/Seoul')}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('yyyy-MM-dd Z', 'Asia/Seoul')}"
         And ZonedDateTime object for "2007-12-03T16:15:30+07:00[Asia/Bangkok]"
         Then expect the template to return "2007-12-03 +0900"
 
     Scenario: Test that using a preset ZonedDateTime inside a template will return the default time zone when a pattern and zone id is given and german locale
         Given an freemarker environment with locale set to "de-DE"
-        Given a template "${obj.format('yyyy MMMM EEEE Z', 'Asia/Seoul')}"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('yyyy MMMM EEEE Z', 'Asia/Seoul')}"
         And ZonedDateTime object for "2007-12-03T16:15:30+07:00[Asia/Bangkok]"
         Then expect the template to return "2007 Dezember Montag +0900"
 
     ### ZoneId ###
     Scenario: Test basic ZoneId use in template
-        Given a template "${obj}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj}"
         And a ZoneId object for 'Europe/Oslo'
         Then expect the template to return "Central European Time"
 
     Scenario: Test that using ZoneId inside a template will return the toString() value
-        Given a template "${obj.format('short')}"
+        Given an freemarker environment with locale set to "fi-FI"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('short')}"
         And a ZoneId object for 'Europe/Oslo'
         Then expect the template to return "CET"
 
 
     ### ZoneOffset ###
     Scenario: Test basic ZoneOffset use in template
-        Given a template "${obj}"
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj}"
         And ZoneOffset object for "2"
         Then expect the template to return "+02:00"

--- a/src/test/resources/no/api/freemarker/java8/time/datetime.feature
+++ b/src/test/resources/no/api/freemarker/java8/time/datetime.feature
@@ -10,7 +10,6 @@ Feature: Test the date time functionality
         And Clock object for "2007-12-03T10:15:30.00Z"
         Then expect the template to return "FixedClock[2007-12-03T10:15:30Z,Europe/Oslo]"
 
-
     ### Duration ###
     Scenario: Test basic Duration use in template
         Given a template "${obj}"
@@ -33,13 +32,28 @@ Feature: Test the date time functionality
         And Instant object for "2007-12-03T10:15:30.00Z"
         Then expect the template to return "2007-12-03T10:15:30Z"
 
-
     ### LocalDate ###
     Scenario: Test basic LocalDate use in template
         Given a template "${obj}"
         And LocalDate object for "2007-12-03"
         Then expect the template to return "2007-12-03"
 
+    Scenario: Test LocalDate use in template with custom pattern
+        Given a template "${obj.format('EEEE d MMMM yyyy')}"
+        And LocalDate object for "2007-12-03"
+        Then expect the template to return "mandag 3 desember 2007"
+
+    Scenario: Test LocalDate use in template with custom pattern and german locale
+        Given an freemarker environment with locale set to "de-DE"
+        Given a template "${obj.format('EEEE d MMMM yyyy')}"
+        And LocalDate object for "2007-12-03"
+        Then expect the template to return "Montag 3 Dezember 2007"
+
+    Scenario: Test LocalDate use in template with custom pattern and arabic locale
+        Given an freemarker environment with locale set to "ar-DZ"
+        Given a template "${obj.format('EEEE d MMMM yyyy')}"
+        And LocalDate object for "2007-12-03"
+        Then expect the template to return "الاثنين 3 ديسمبر 2007"
 
     ### LocalDateTime ###
     Scenario: Test basic LocalDateTime use in template
@@ -47,6 +61,16 @@ Feature: Test the date time functionality
         And LocalDateTime object for "2007-12-03T10:15:30"
         Then expect the template to return "2007-12-03T10:15:30"
 
+    Scenario: Test basic LocalDateTime use in template with custom pattern
+        Given a template "${obj.format('EEEE d MMMM yyyy HH:mm:ss')}"
+        And LocalDateTime object for "2007-12-03T10:15:30"
+        Then expect the template to return "mandag 3 desember 2007 10:15:30"
+
+    Scenario: Test basic LocalDateTime use in template with custom pattern and romanian locale
+        Given an freemarker environment with locale set to "ro-RO"
+        Given a template "${obj.format('EEEE d MMMM yyyy HH:mm:ss')}"
+        And LocalDateTime object for "2007-12-03T10:15:30"
+        Then expect the template to return "luni 3 decembrie 2007 10:15:30"
 
     ### LocalTime ###
     Scenario: Test basic LocalTime use in template
@@ -54,13 +78,22 @@ Feature: Test the date time functionality
         And LocalTime object for "23:44"
         Then expect the template to return "23:44"
 
-
     ### MonthDay ###
     Scenario: Test basic MonthDay use in template
         Given a template "${obj}"
-        And MonthDay object for "--03-14"
-        Then expect the template to return "--03-14"
+        And MonthDay object for "--10-14"
+        Then expect the template to return "--10-14"
 
+    Scenario: Test basic MonthDay use in template with custom pattern
+        Given a template "${obj.format('MMMM')}"
+        And MonthDay object for "--10-14"
+        Then expect the template to return "oktober"
+
+    Scenario: Test basic MonthDay use in template with custom pattern and french locale
+        Given an freemarker environment with locale set to "fr-FR"
+        Given a template "${obj.format('MMMM')}"
+        And MonthDay object for "--10-14"
+        Then expect the template to return "octobre"
 
     ### OffsetDateTime ###
     Scenario: Test basic OffsetDateTime use in template
@@ -68,13 +101,22 @@ Feature: Test the date time functionality
         And OffsetDateTime object for "2007-12-03T10:15:30+01:00"
         Then expect the template to return "2007-12-03T10:15:30+01:00"
 
+    Scenario: Test basic OffsetDateTime use in template with custom pattern
+        Given a template "${obj.format('YYYY MMMM EEEE d HH:mm:ss Z')}"
+        And OffsetDateTime object for "2007-12-03T10:15:30+01:00"
+        Then expect the template to return "2007 desember mandag 3 10:15:30 +0100"
+
+    Scenario: Test basic OffsetDateTime use in template with custom pattern and finnish locale
+        Given an freemarker environment with locale set to "fi-FI"
+        Given a template "${obj.format('YYYY MMMM EEEE d HH:mm:ss Z')}"
+        And OffsetDateTime object for "2007-12-03T10:15:30+01:00"
+        Then expect the template to return "2007 joulukuuta maanantai 3 10:15:30 +0100"
 
     ### OffsetTime ###
     Scenario: Test basic OffsetTime use in template
         Given a template "${obj}"
         And OffsetTime object for "23:44+01:00"
         Then expect the template to return "23:44+01:00"
-
 
     ### Period ###
     Scenario: Test basic Period use in template
@@ -124,7 +166,6 @@ Feature: Test the date time functionality
         Then expect the template to return "2007 - 11"
 
     ### ZonedDateTime ###
-
     Scenario: Test basic ZonedDateTime use in template.
         Given a template "${obj}"
         And ZonedDateTime object for "2007-12-03T10:15:30+01:00[Europe/Paris]"
@@ -140,8 +181,13 @@ Feature: Test the date time functionality
         And ZonedDateTime object for "2007-12-03T16:15:30+07:00[Asia/Bangkok]"
         Then expect the template to return "2007-12-03 +0900"
 
-    ### ZoneId ###
+    Scenario: Test that using a preset ZonedDateTime inside a template will return the default time zone when a pattern and zone id is given and german locale
+        Given an freemarker environment with locale set to "de-DE"
+        Given a template "${obj.format('yyyy MMMM EEEE Z', 'Asia/Seoul')}"
+        And ZonedDateTime object for "2007-12-03T16:15:30+07:00[Asia/Bangkok]"
+        Then expect the template to return "2007 Dezember Montag +0900"
 
+    ### ZoneId ###
     Scenario: Test basic ZoneId use in template
         Given a template "${obj}"
         And a ZoneId object for 'Europe/Oslo'
@@ -154,7 +200,6 @@ Feature: Test the date time functionality
 
 
     ### ZoneOffset ###
-
     Scenario: Test basic ZoneOffset use in template
         Given a template "${obj}"
         And ZoneOffset object for "2"


### PR DESCRIPTION
…ad of the Locale set in the FreeMarker configuration.

Reimplementation of the locale fix from PR#2  https://github.com/amedia/freemarker-java-8/pull/2
But with tests and some extra security in order to not run into any NPE's during startup.

I consider this as a bugfix. 