### PR TITLE
DateTimeFormatter bug

### DIFF
--- a/src/main/java/no/api/freemarker/java8/time/LocalDateTimeAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalDateTimeAdapter.java
@@ -58,7 +58,7 @@ public class LocalDateTimeAdapter extends AbstractAdapter<LocalDateTime> impleme
 
         @Override
         public Object exec(List list) throws TemplateModelException {
-            return getObject().format(createDateTimeFormatter(list, 0, DateTimeFormatter.ISO_ZONED_DATE_TIME));
+            return getObject().format(createDateTimeFormatter(list, 0, DateTimeFormatter.ISO_LOCAL_DATE_TIME));
         }
     }
 }


### PR DESCRIPTION
for LocalDateTime you should use DateTimeFormatter.ISO_LOCAL_DATE_TIME instead of DateTimeFormatter.ISO_ZONED_DATE_TIME