### PR TITLE
Fixes #13. Adds support for format styles

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -96,18 +96,18 @@ for formatting.
 
 |LocalDate
 |`format(), format(pattern)`
-|Allows you to print a LocalDate on a default pattern or by providing a custom pattern.
-|`${mylocaldate.format()}` or `${mylocaldate.format('yyyy MM dd')}`
+|Allows you to print a LocalDate on a default pattern, by providing a custom pattern or a builtin format style.
+|`${mylocaldate.format()}`, `${mylocaldate.format('yyyy MM dd')}` or `${mylocaldate.format('FULL_DATE')}`
 
 |LocalDateTime
 |`format(), format(pattern)`
-|Allows you to print a LocalDateTime on a default pattern or by providing a custom pattern.
-|`${mylocaldatetime.format()}` or `${mylocaldatetime.format('yyyy-MM-dd HH : mm : ss')}`
+|Allows you to print a LocalDateTime on a default pattern, by providing a custom pattern or a builtin format style.
+|`${mylocaldatetime.format()}`, `${mylocaldatetime.format('yyyy-MM-dd HH : mm : ss')}` or `${mylocaldatetime.format('MEDIUM_DATETIME')}`
 
 |LocalTime
 |`format(), format(pattern)`
-|Allows you to print a LocalTime on a default pattern or by providing a custom pattern.
-|`${mylocaltime.format()}` or `${mylocaltime.format('HH : mm : ss')}`
+|Allows you to print a LocalTime on a default pattern, by providing a custom pattern or a builtin format style.
+|`${mylocaltime.format()}`, `${mylocaltime.format('HH : mm : ss')}` or `${mylocaltime.format('SHORT_TIME')}`
 
 |MonthDay
 |`format(), format(pattern)`
@@ -116,13 +116,13 @@ for formatting.
 
 |OffsetDateTime
 |`format(), format(pattern)`
-|Allows you to print a OffsetDateTime on a default pattern or by providing a custom pattern.
-|`${myoffsetdatetime.format()}` or `${myoffsetdatetime.format('yyyy MM dd HH mm ss')}`
+|Allows you to print a OffsetDateTime on a default pattern, by providing a custom pattern or a builtin format style.
+|`${myoffsetdatetime.format()}`, `${myoffsetdatetime.format('yyyy MM dd HH mm ss')}` or `${myoffsetdatetime.format('FULL_DATETIME')}`
 
 |OffsetTime
 |`format(), format(pattern)`
-|Allows you to print a OffsetTime on a default pattern or by providing a custom pattern.
-|`${myoffsettime.format()}` or `${myoffsettime.format('HH mm ss')}`
+|Allows you to print a OffsetTime on a default pattern, by providing a custom pattern or a builtin format style.
+|`${myoffsettime.format()}`, `${myoffsettime.format('HH mm ss')}` or `${myoffsettime.format('MEDIUM_TIME')}`
 
 |Period
 |`days(), months(), years()`
@@ -141,7 +141,7 @@ for formatting.
 
 |ZonedDateTime
 |`format(), format(pattern), format(pattern, zoneId)`
-|Allows you to print a YearMonth on a default pattern/timezone or by providing a custom pattern and timezone.
+|Allows you to print a YearMonth on a default pattern/timezone or by providing a custom pattern.
 |`${myzoneddatetime.format()}` or `${myzoneddatetime.format('yyyy-MM-dd Z')}` or `${myzoneddatetime.format('yyyy-MM-dd Z', 'Asia/Seoul')}`
 
 |ZoneId

--- a/src/main/java/no/api/freemarker/java8/time/DateTimeTools.java
+++ b/src/main/java/no/api/freemarker/java8/time/DateTimeTools.java
@@ -64,7 +64,22 @@ public final class DateTimeTools {
                                                             int index,
                                                             final DateTimeFormatter defaultFormatter) {
         if (list.size() > 0) {
-            return DateTimeFormatter.ofPattern(((SimpleScalar) list.get(index)).getAsString(), getLocale());
+            String format = ((SimpleScalar) list.get(index)).getAsString();
+            ExtFormatStyle style = getFormatStyle(format);
+
+            if(style == null) {
+                return DateTimeFormatter.ofPattern(format, getLocale());
+            } else {
+                DateTimeFormatter formatter;
+                if(style.withDate && style.withTime) {
+                    formatter = DateTimeFormatter.ofLocalizedDateTime(style.javaFormatStyle);
+                } else if(style.withDate) {
+                    formatter = DateTimeFormatter.ofLocalizedDate(style.javaFormatStyle);
+                } else {
+                    formatter = DateTimeFormatter.ofLocalizedTime(style.javaFormatStyle);
+                }
+                return formatter.withLocale(getLocale());
+            }
         }
         return defaultFormatter.withLocale(getLocale());
     }
@@ -122,6 +137,14 @@ public final class DateTimeTools {
             return Environment.getCurrentEnvironment().getLocale();
         } else {
             return Locale.getDefault();
+        }
+    }
+
+    private static ExtFormatStyle getFormatStyle(String format) {
+        try {
+            return ExtFormatStyle.valueOf(format);
+        } catch(IllegalArgumentException | NullPointerException ex) {
+            return null;
         }
     }
 

--- a/src/main/java/no/api/freemarker/java8/time/ExtFormatStyle.java
+++ b/src/main/java/no/api/freemarker/java8/time/ExtFormatStyle.java
@@ -1,0 +1,25 @@
+package no.api.freemarker.java8.time;
+
+import java.time.format.FormatStyle;
+
+public enum ExtFormatStyle {
+    LONG_DATE(true, false, FormatStyle.LONG),
+    LONG_DATETIME(true, true, FormatStyle.LONG),
+    LONG_TIME(false, true, FormatStyle.LONG),
+    MEDIUM_DATE(true, false, FormatStyle.MEDIUM),
+    MEDIUM_DATETIME(true, true, FormatStyle.MEDIUM),
+    MEDIUM_TIME(false, true, FormatStyle.MEDIUM),
+    SHORT_DATE(true, false, FormatStyle.SHORT),
+    SHORT_DATETIME(true, true, FormatStyle.SHORT),
+    SHORT_TIME(false, true, FormatStyle.SHORT);
+
+    final boolean withDate;
+    final boolean withTime;
+    final FormatStyle javaFormatStyle;
+
+    ExtFormatStyle(boolean withDate, boolean withTime, FormatStyle formatStyle) {
+        this.withDate = withDate;
+        this.withTime = withTime;
+        this.javaFormatStyle = formatStyle;
+    }
+}

--- a/src/test/resources/no/api/freemarker/java8/time/datetime.feature
+++ b/src/test/resources/no/api/freemarker/java8/time/datetime.feature
@@ -82,6 +82,27 @@ Feature: Test the date time functionality
         And LocalDateTime object for "2007-12-03T10:15:30"
         Then expect the template to return "mandag 3 desember 2007 10:15:30"
 
+    Scenario: Test basic LocalDateTime use in template with LONG_DATE
+        Given an freemarker environment with locale set to "no-No"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('LONG_DATE')}"
+        And LocalDateTime object for "2007-12-03T10:15:30"
+        Then expect the template to return "3. desember 2007"
+
+    Scenario: Test basic LocalDateTime use in template with MEDIUM_DATETIME
+        Given an freemarker environment with locale set to "no-No"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('MEDIUM_DATETIME')}"
+        And LocalDateTime object for "2007-12-03T10:15:30"
+        Then expect the template to return "03.des.2007 10:15:30"
+
+    Scenario: Test basic LocalDateTime use in template with SHORT_TIME
+        Given an freemarker environment with locale set to "no-No"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('SHORT_TIME')}"
+        And LocalDateTime object for "2007-12-03T10:15:30"
+        Then expect the template to return "10:15"
+
     Scenario: Test basic LocalDateTime use in template with custom pattern and romanian locale
         Given an freemarker environment with locale set to "ro-RO"
         And timezone set to "Europe/Oslo"


### PR DESCRIPTION
This PR fixes #13 by adding support for using format styles in addition to patterns.

It makes use of the builtin format styles in the JRE, so that a program can simply set what kind of date style it wants instead of specifying the exact pattern.

Fx. given the date `2018-01-01 12:00:00` The following outputs can be excepted for Locale 'da-DK':
* `${obj.format('LONG_DATE')}` -> `1. januar 2018`  
* `${obj.format('MEDIUM_DATETIME')}` -> `1. jan 2018 12:00:00`
* `${obj.format('SHORT_TIME')}` -> `12:00`