### PR TITLE
32 it doesnt work in freemarker version 2 3 31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [freemarker-java8-2.0.0](https://github.com/amedia/freemarker-java-8/tree/freemarker-java8-2.0.0) (2020-03-10)
+
 - Allow fall-through to default methods in the java.time classes (Thank you @mihxil)
 - Proper handling of ZoneId for ZonedDateTime formatting (Breaking change in default behaviour)
 - Github Actions build
@@ -8,11 +9,10 @@
 
 ## [freemarker-java8-1.2.0](https://github.com/amedia/freemarker-java-8/tree/freemarker-java8-1.2.0) (2017-08-08)
 
-- Fixed formatter bug reported and fixed by @tifoha (https://github.com/amedia/freemarker-java-8/commit/92d1e7d6f0310d946b516cb008479e5de427dca6)
-- Added support for isEqual, isAfter and isBefore as suggested by @kingmaoam. (https://github.com/amedia/freemarker-java-8/pull/10/files)
+- Fixed formatter bug reported and fixed by @tifoha [](https://github.com/amedia/freemarker-java-8/commit/92d1e7d6f0310d946b516cb008479e5de427dca6)
+- Added support for isEqual, isAfter and isBefore as suggested by @kingmaoam. [](https://github.com/amedia/freemarker-java-8/pull/10/files)
 
-Note: As we had some issues with the 1.1.6 deployment, the changelig for this release also contains some changes from that release. 
-
+Note: As we had some issues with the 1.1.6 deployment, the changelig for this release also contains some changes from that release.
 
 ## [freemarker-java8-1.1.6](https://github.com/amedia/freemarker-java-8/tree/freemarker-java8-1.1.6) (2017-07-24)
 
@@ -39,6 +39,3 @@ Note: As we had some issues with the 1.1.6 deployment, the changelig for this re
 
 - \#6 Fixed [\#7](https://github.com/amedia/freemarker-java-8/pull/7) ([lazee](https://github.com/lazee))
 - Update installation documentation [\#4](https://github.com/amedia/freemarker-java-8/pull/4) ([mthmulders](https://github.com/mthmulders))
-
-
-

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,5 @@
+# Contributors
+
+*Desson Ariawan for the Spring example [example](https://www.dariawan.com/tutorials/spring/java-8-datetime-freemarker/)*
+
+*[hercsoft](https://github.com/hercsoft) for letting us know about FreeMarker expression builders*

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ the default object wrapper with the FJ8 implementation in your FreeMarker Config
 
 ```java
 this.configuration = new Configuration(); // Or get the configuration from your framework like DropWizard or Spring Boot.
-this.configuration.setObjectWrapper(new Java8ObjectWrapper(Configuration.VERSION_2_3_23));
+this.configuration.setObjectWrapper(new Java8ObjectWrapper(Configuration.VERSION_2_3_31));
 ```
 
 ### Spring setup
@@ -164,8 +164,8 @@ to be converted into your local timezone.
 ##### Examples
 
 ```java
-this.objectWrapper = new Java8ObjectWrapper(VERSION_2_3_23, new KeepingZoneStrategy());
-this.objectWrapper = new Java8ObjectWrapper(VERSION_2_3_23, new StaticZoneStrategy(ZoneId.of("Europe/Oslo")));
+this.objectWrapper = new Java8ObjectWrapper(VERSION_2_3_31, new KeepingZoneStrategy());
+this.objectWrapper = new Java8ObjectWrapper(VERSION_2_3_31, new StaticZoneStrategy(ZoneId.of("Europe/Oslo")));
 ```
 
 #### :ballot_box_with_check: java.time.Clock
@@ -423,9 +423,9 @@ ${myzoneddatetime.format('yyyy-MM-dd HH mm s Z', 'Asia/Seoul')}
 Example:
 
 ```java
-new Java8ObjectWrapper(VERSION_2_3_23, new EnvironmentZoneStrategy());
+new Java8ObjectWrapper(VERSION_2_3_31, new EnvironmentZoneStrategy());
 // or
-new Java8ObjectWrapper(VERSION_2_3_23, new StaticZoneStrategy(ZoneId.of("Europe/Oslo")));
+new Java8ObjectWrapper(VERSION_2_3_31, new StaticZoneStrategy(ZoneId.of("Europe/Oslo")));
 ```
 
 #### :ballot_box_with_check: java.time.ZonedId

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # java.time support for FreeMarker
-![](https://github.com/lazee/freemarker-java-8/workflows/Build%20project/badge.svg)
+
+![build status](https://github.com/lazee/freemarker-java-8/workflows/Build%20project/badge.svg)
 
 FJ8 (freemarker-java-8) is a Java library that adds java.time api support to FreeMarker. It is easy to add to your codebase, and very easy to use.
 
@@ -13,40 +14,39 @@ native support, but it doesn't look promising (<http://freemarker.org/contribute
 Basically this library allows you to format java.time types within your templates, using the new
 [java.time.format.DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html).
 
-# Table of content
-* [Installation](#installation)
-* [Setup](#setup)
-* [Upgrade from 1.3 to 2.0](#upgrade-from-13-to-20)
-* [Usage](#usage)
-    + [Formatting](#formatting)
-      - [java.time.Clock](#user-content-ballot_box_with_check-javatimeclock)
-      - [java.time.Duration](#user-content-ballot_box_with_check-javatimeduration)
-      - [java.time.Instant](#user-content-ballot_box_with_check-javatimeinstant)
-      - [java.time.LocalDate](#user-content-ballot_box_with_check-javatimelocaldate)
-      - [java.time.LocalDateTime](#user-content-ballot_box_with_check-javatimelocaldatetime)
-      - [java.time.LocalTime](#user-content-ballot_box_with_check-javatimelocaltime)
-      - [java.time.MonthDay](#user-content-ballot_box_with_check-javatimemonthday)
-      - [java.time.OffsetDateTime](#user-content-ballot_box_with_check-javatimeoffsetdatetime)
-      - [java.time.OffsetTime](#user-content-ballot_box_with_check-javatimeoffsettime)
-      - [java.time.Period](#user-content-ballot_box_with_check-javatimeperiod)
-      - [java.time.Year](#user-content-ballot_box_with_check-javatimeyear)
-      - [java.time.YearMonth](#user-content-ballot_box_with_check-javatimeyearmonth)
-      - [java.time.ZonedDateTime](#user-content-ballot_box_with_check-javatimezoneddatetime)
-      - [java.time.ZonedId](#user-content-ballot_box_with_check-javatimezonedid)
-      - [java.time.ZonedOffset](#user-content-ballot_box_with_check-javatimezonedoffset)
-    + [Comparison](#comparison)
-      - [java.time.LocalDate](#user-content-ballot_box_with_check-javatimelocaldate-1)
-      - [java.time.LocalDateTime](#user-content-ballot_box_with_check-javatimelocaldatetime-1)
-      - [java.time.LocalTime](#user-content-ballot_box_with_check-javatimelocaltime-1)
-* [Notice](#notice)
+## Table of content
 
+- [Installation](#installation)
+- [Setup](#setup)
+- [Upgrade guides](#upgrade-guides)
+- [Usage](#usage)
+  - [Formatting](#formatting)
+    - [java.time.Clock](#user-content-ballot_box_with_check-javatimeclock)
+    - [java.time.Duration](#user-content-ballot_box_with_check-javatimeduration)
+    - [java.time.Instant](#user-content-ballot_box_with_check-javatimeinstant)
+    - [java.time.LocalDate](#user-content-ballot_box_with_check-javatimelocaldate)
+    - [java.time.LocalDateTime](#user-content-ballot_box_with_check-javatimelocaldatetime)
+    - [java.time.LocalTime](#user-content-ballot_box_with_check-javatimelocaltime)
+    - [java.time.MonthDay](#user-content-ballot_box_with_check-javatimemonthday)
+    - [java.time.OffsetDateTime](#user-content-ballot_box_with_check-javatimeoffsetdatetime)
+    - [java.time.OffsetTime](#user-content-ballot_box_with_check-javatimeoffsettime)
+    - [java.time.Period](#user-content-ballot_box_with_check-javatimeperiod)
+    - [java.time.Year](#user-content-ballot_box_with_check-javatimeyear)
+    - [java.time.YearMonth](#user-content-ballot_box_with_check-javatimeyearmonth)
+    - [java.time.ZonedDateTime](#user-content-ballot_box_with_check-javatimezoneddatetime)
+    - [java.time.ZonedId](#user-content-ballot_box_with_check-javatimezonedid)
+    - [java.time.ZonedOffset](#user-content-ballot_box_with_check-javatimezonedoffset)
+  - [Comparison](#comparison)
+    - [java.time.LocalDate](#user-content-ballot_box_with_check-javatimelocaldate-1)
+    - [java.time.LocalDateTime](#user-content-ballot_box_with_check-javatimelocaldatetime-1)
+    - [java.time.LocalTime](#user-content-ballot_box_with_check-javatimelocaltime-1)
 
-# Installation
+## Installation
 
 You need Java 8 or higher. FJ8 is tested on Freemarker 2.3.23, and should at least work
-fine for all 2.3.x versions. 
+fine for all 2.3.x versions.
 
-## Maven
+### Maven
 
 ```xml
 <dependency>
@@ -56,11 +56,13 @@ fine for all 2.3.x versions.
 </dependency>
 ```
 
-## Gradle
+### Gradle
 
-	implementation 'no.api.freemarker:freemarker-java8:2.0.0'
+```gradle
+implementation 'no.api.freemarker:freemarker-java8:2.0.0'
+```
 
-# Setup
+## Setup
 
 FJ8 extends the [DefaultObjectWrapper](https://freemarker.apache.org/docs/api/freemarker/template/DefaultObjectWrapper.html) to add support for the java.time classes. All you need to do is to replace
 the default object wrapper with the FJ8 implementation in your FreeMarker Configuration object.
@@ -70,7 +72,7 @@ this.configuration = new Configuration(); // Or get the configuration from your 
 this.configuration.setObjectWrapper(new Java8ObjectWrapper(Configuration.VERSION_2_3_23));
 ```
 
-## Spring setup
+### Spring setup
 
 This is how you can add FJ8 to your FreeMarker configuration in Spring / Spring Boot.
 
@@ -102,7 +104,7 @@ public class FreemarkerConfig implements BeanPostProcessor {
 
 You can also configure it via Spring boot properties like this:
 
-```
+```java
 spring.freemarker.settings.object_wrapper=no.api.freemarker.java8.Java8ObjectWrapper(Configuration.VERSION_2_3_31)
 ```
 
@@ -110,227 +112,261 @@ This takes advantage of Freemarker Configuration [object builder expressions](ht
 
 *Thanks to [hercsoft](https://github.com/hercsoft) for letting us know*
 
+## Upgrade guides
 
-# Upgrade from 1.3 to 2.0
+Upgrade information has moved to [UPGRADE.md](upgrade.md)
 
-The 2.0 release addresses two major issues reported by users ([#18](https://github.com/lazee/freemarker-java-8/issues/18)/[#16](https://github.com/lazee/freemarker-java-8/issues/16)). It also introduces a new feature for manipulating time ([\#28](https://github.com/lazee/freemarker-java-8/pull/28)).  
+## Usage
 
-The upgrade itself is nothing else than changing the version in your build configuration (pom.xml or something else). However if you need to stick to the old behaviour on how time zones are treated when formatting ZonedDateTime objects, then you need to add a second argument to Java8ObjectWrapper upon initialization:
+### Formatting java.time classes
 
-```java
-configuration.setObjectWrapper(
-	new Java8ObjectWrapper(VERSION_2_3_23, new EnvironmentTimeStrategy()
-);
-```
-
-
-# Usage
-
-## Formatting java.time classes
 All format methods uses the
 [java.time.format.DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html)
 for formatting.
 
-### :ballot_box_with_check: java.time.Clock
+#### :ballot_box_with_check: java.time.Clock
 
 This is a simple implementation where format just prints the toString() value of the object.
 
-#### Methods
+##### Methods
 
-* format()
-	
-#### Example
+- format()
+- format(pattern)
+- format(pattern, zone)
 
-	${myclock.format()}
+##### Example
 
-### java.time.Duration
+```freemarker
+${myclock.format()}
+${myclock.format('yyyy-MM-dd Z')}
+${myclock.format('yyyy-MM-dd Z', 'Asia/Seoul')}
+```
+
+#### java.time.Duration
 
 Gives access to the Duration values.
 
-#### Methods
+##### Methods
 
-* nano()
-* seconds()
-	
-#### Example
+- nano()
+- seconds()
 
-	${myduration.seconds}
-	${myduration.nano}
-	
+##### Example
 
-### :ballot_box_with_check: java.time.Instant
+```freemarker
+${myduration.seconds}
+${myduration.nano}
+```
+
+#### :ballot_box_with_check: java.time.Instant
 
 This is a simple implementation where format just prints the toString() value of the object.
 
-#### Methods
+##### Methods
 
-* format()
-* format(pattern)
-	
-#### Example
+- format()
+- format(pattern)
+- format(pattern, zone)
 
-	${myinstant.format()}
+##### Example
 
-### :ballot_box_with_check: java.time.LocalDate
+```freemarker
+${myinstant.format()}
+${myzoneddatetime.format('yyyy-MM-dd Z')}
+${myzoneddatetime.format('yyyy-MM-dd Z', 'Asia/Seoul')}
+```
+
+#### :ballot_box_with_check: java.time.LocalDate
 
 Allows you to print a LocalDate on a default pattern, by providing a custom pattern or a builtin format style.
 
-#### Methods
+##### Methods
 
-* format()
-	
-#### Example
+- format()
+- format(pattern)
+- format(pattern, zone)
 
-	${mylocaldate.format()}
-	${mylocaldate.format('yyyy MM dd')}
-	${mylocaldate.format('FULL_DATE')}
+##### Example
 
-### :ballot_box_with_check: java.time.LocalDateTime
+```freemarker
+${mylocaldate.format()}
+${mylocaldate.format('yyyy MM dd')}
+${mylocaldate.format('FULL_DATE')}
+${mylocaldate.format('yyyy MM dd', 'Asia/Seoul')}
+```
+
+#### :ballot_box_with_check: java.time.LocalDateTime
 
 Allows you to print a LocalDateTime on a default pattern, by providing a custom pattern or a builtin format style.
 
-#### Methods
+##### Methods
 
-* format()
-* format(pattern)
-	
-#### Example
+- format()
+- format(pattern)
+- format(pattern, zone)
 
-	${mylocaldatetime.format()}
-	${mylocaldatetime.format('yyyy-MM-dd HH : mm : ss')}
-	${mylocaldatetime.format('MEDIUM_DATETIME')}
+##### Example
 
-### :ballot_box_with_check: java.time.LocalTime
+```freemarker
+${mylocaldatetime.format()}
+${mylocaldatetime.format('yyyy-MM-dd HH : mm : ss')}
+${mylocaldatetime.format('MEDIUM_DATETIME')}
+${mylocaldatetime.format('yyyy-MM-dd HH : mm : ss', 'Asia/Seoul')}
+```
+
+#### :ballot_box_with_check: java.time.LocalTime
 
 Allows you to print a LocalTime on a default pattern, by providing a custom pattern or a builtin format style.
 
-#### Methods
+##### Methods
 
-* format()
-* format(pattern)
-	
-#### Example
+- format()
+- format(pattern)
+- format(pattern, zone)
 
-	${mylocaltime.format()}
-	${mylocaltime.format('HH : mm : ss')}
-	${mylocaltime.format('SHORT_TIME')}
+##### Example
 
-### :ballot_box_with_check: java.time.MonthDay
+```freemarker
+${mylocaltime.format()}
+${mylocaltime.format('HH : mm : ss')}
+${mylocaltime.format('SHORT_TIME')}
+${mylocaltime.format('HH : mm : ss', 'Asia/Seoul')}
+```
+
+#### :ballot_box_with_check: java.time.MonthDay
 
 Allows you to print a MonthDay on a default pattern or by providing a custom pattern.
 
-#### Methods
+##### Methods
 
-* format()
-* format(pattern)
-	
-#### Example
+- format()
+- format(pattern)
+- format(pattern, zone)
 
-	${mymonthday.format()}
-	${mymonthday.format('MM dd')}
+##### Example
 
-### :ballot_box_with_check: java.time.OffsetDateTime
+```freemarker
+${mymonthday.format()}
+${mymonthday.format('MM dd')}
+${mymonthday.format('MM dd', 'Asia/Seoul')}
+```
+
+#### :ballot_box_with_check: java.time.OffsetDateTime
 
 Allows you to print a OffsetDateTime on a default pattern, by providing a custom pattern or a builtin format style.
 
-#### Methods
+##### Methods
 
-* format()
-* format(pattern)
-	
-#### Example
+- format()
+- format(pattern)
+- format(pattern, zone)
 
-	${myoffsetdatetime.format()}
-	${myoffsetdatetime.format('yyyy MM dd HH mm ss')}
-	${myoffsetdatetime.format('FULL_DATETIME')}
+##### Example
 
+```freemarker
+${myoffsetdatetime.format()}
+${myoffsetdatetime.format('yyyy MM dd HH mm ss')}
+${myoffsetdatetime.format('FULL_DATETIME')}
+${myoffsetdatetime.format('yyyy MM dd HH mm ss', 'Asia/Seoul')}
+```
 
-### :ballot_box_with_check: java.time.OffsetTime
+#### :ballot_box_with_check: java.time.OffsetTime
 
 Allows you to print a OffsetTime on a default pattern, by providing a custom pattern or a builtin format style.
 
-#### Methods
+##### Methods
 
-* format()
-* format(pattern)
-	
-#### Example
+- format()
+- format(pattern)
+- format(pattern, zone)
 
-	${myoffsettime.format()}
-	${myoffsettime.format('HH mm ss')}
-	${myoffsettime.format('MEDIUM_TIME')}
+##### Example
 
-### :ballot_box_with_check: java.time.Period
+```freemarker
+${myoffsettime.format()}
+${myoffsettime.format('HH mm ss')}
+${myoffsettime.format('MEDIUM_TIME')}
+${myoffsettime.format('HH mm ss', 'Asia/Seoul')}
+```
+
+#### :ballot_box_with_check: java.time.Period
 
 Provides access to the values of the a Period object within your template.
 
-#### Methods
+##### Methods
 
-* days()
-* months()
-* years()
-	
-#### Example
+- days()
+- months()
+- years()
 
-	${myperiod.days}
-	${myperiod.months}
-	${myperiod.years}
+##### Example
 
-### :ballot_box_with_check: java.time.Year
+```freemarker
+${myperiod.days}
+${myperiod.months}
+${myperiod.years}
+```
+
+#### :ballot_box_with_check: java.time.Year
 
 Allows you to print a Year on a default pattern or by providing a custom pattern.
 
-#### Methods
+##### Methods
 
-* format()
-* format(pattern)
-	
-#### Example
+- format()
+- format(pattern)
 
-	${myyear.format()}
-	${myyear.format('yyyy')}
+##### Example
 
-### :ballot_box_with_check: java.time.YearMonth
+```freemarker
+${myyear.format()}
+${myyear.format('yyyy')}
+```
+
+#### :ballot_box_with_check: java.time.YearMonth
 
 Allows you to print a YearMonth on a default pattern or by providing a custom pattern.
 
-#### Methods
+##### Methods
 
-* format()
-* format(pattern)
-	
-#### Example
+- format()
+- format(pattern)
 
-	${myyear.format()}
-	${myyear.format('yyyy MM')}
+##### Example
 
-### :ballot_box_with_check: java.time.ZonedDateTime
+```freemarker
+${myyear.format()}
+${myyear.format('yyyy MM')}
+```
+
+#### :ballot_box_with_check: java.time.ZonedDateTime
 
 Allows you to print a YearMonth on a default pattern/timezone or by providing a custom pattern.
 
-#### Methods
+##### Methods
 
-* format()
-* format(pattern)
-* format(pattern, zone)
+- format()
+- format(pattern)
+- format(pattern, zone)
 
-#### Example
+##### Example
 
-	${myzoneddatetime.format()}
-	${myzoneddatetime.format('yyyy-MM-dd Z')}
-	${myzoneddatetime.format('yyyy-MM-dd Z', 'Asia/Seoul')}
+```freemarker
+${myzoneddatetime.format()}
+${myzoneddatetime.format('yyyy-MM-dd Z')}
+${myzoneddatetime.format('yyyy-MM-dd Z', 'Asia/Seoul')}
+```
 
-#### Notice
+##### Notice
 
-When a zone is _not_ set, the formatter will use the zone found in the ZonedDateTime object itself. This behaviour can be changed if you want to. Scenarious where that might come in handy could be when you always wants to convert the timezone into your local timezone.
+When a zone is *not* set, the formatter will use the zone found in the ZonedDateTime object itself. This behaviour can be changed if you want to. Scenarious where that might come in handy could be when you always wants to convert the timezone into your local timezone.
 
-`Java8ObjectMapper`now takes a second argument where you can choose one of four strategies for 
-the time zone used when formatting a ZonedDateTime:
+`Java8ObjectMapper`now takes a second argument where you can choose one of four strategies for the time zone used when formatting a ZonedDateTime:
 
-* **EnviromentZonedDateTimeStrategy** - Will convert the time zone into the one currently set within Freemarker.
-* **KeepingZonedDateTimeStrategy** - Will use the zone from the ZonedDateTime object itself (DEFAULT)
-* **SystemZonedDateTimeStrategy** - Will convert the time zone into ZoneId.systemDefault().
-* **StaticSystemZoneDateTimeStrategy** - Will use the time zone set when creating this strategy.
+- **EnviromentZonedDateTimeStrategy** - Will convert the time zone into the one currently set within Freemarker.
+- **KeepingZonedDateTimeStrategy** - Will use the zone from the ZonedDateTime object itself (DEFAULT)
+- **SystemZonedDateTimeStrategy** - Will convert the time zone into ZoneId.systemDefault().
+- **StaticSystemZoneDateTimeStrategy** - Will use the time zone set when creating this strategy.
 
 Example:
 
@@ -339,125 +375,126 @@ new Java8ObjectWrapper(VERSION_2_3_23, new EnvironmentZonedDateTimeStrategy());
 // or
 new Java8ObjectWrapper(VERSION_2_3_23, new StaticZonedDateTimeStrategy(ZoneId.of("Europe/Oslo")));
 ```
-	
-### :ballot_box_with_check: java.time.ZonedId
+
+#### :ballot_box_with_check: java.time.ZonedId
 
 Prints the ZoneId display name. You can override the textstyle with one of these values [FULL, FULL_STANDALONE, SHORT, SHORT_STANDALONE, NARROW and NARROW_STANDALONE]. You can also override the locale, but Java only seems to have locale support for a few languages.
 
-#### Methods
+##### Methods
 
-* format()
-* format(textStyle)
-* format(textstyle, locale)	
+- format()
+- format(textStyle)
+- format(textstyle, locale)
 
-### Example
+#### Example
 
-	${myzoneid.format()}
-	${myzoneid.format('short')}
-	${myzoneid.format('short', 'no-NO')}
+```freemarker
+${myzoneid.format()}
+${myzoneid.format('short')}
+${myzoneid.format('short', 'no-NO')}
+```
 
-### :ballot_box_with_check: java.time.ZonedOffset
+#### :ballot_box_with_check: java.time.ZonedOffset
 
 Prints the ZoneOffset display name. You can override the textstyle with one of these values [FULL, FULL_STANDALONE, SHORT, SHORT_STANDALONE, NARROW and NARROW_STANDALONE]. You can also override the locale, but Java only seems to have locale support for a few languages.</p></td>
 
+##### Methods
 
-#### Methods
+- format()
+- format(textStyle)
 
-* format()
-* format(textStyle)	
+##### Example
 
-#### Example
+```freemarker
+${myzoneoffset.format()}
+${myzoneoffset.format('short')}
+```
 
-	${myzoneoffset.format()}
-	${myzoneoffset.format('short')}
+### Comparison
 
-
-## Comparison
-
-
-### :ballot_box_with_check: java.time.LocalDate
+#### :ballot_box_with_check: java.time.LocalDate
 
 Can compare two LocalDate objects for equality.
 
-#### Methods
+##### Methods
 
-* isEqual(localDate)
-* isAfter(localDate)
-* isBefore(localDate)
+- isEqual(localDate)
+- isAfter(localDate)
+- isBefore(localDate)
 
-#### Example
+##### Example
 
-	${localDate.isEqual(anotherlocalDate)}
-	${localDate.isAfter(anotherlocalDate)}
-	${localDate.isBefore(anotherlocalDate)}
+```freemarker
+${localDate.isEqual(anotherlocalDate)}
+${localDate.isAfter(anotherlocalDate)}
+${localDate.isBefore(anotherlocalDate)}
+```
 
-
-### :ballot_box_with_check: java.time.LocalDateTime
+#### :ballot_box_with_check: java.time.LocalDateTime
 
 Can compare two LocalDateTime objects for equality.
 
-#### Methods
+##### Methods
 
-* isEqual(localDateTime)
-* isAfter(localDateTime)
-* isBefore(localDateTime)
+- isEqual(localDateTime)
+- isAfter(localDateTime)
+- isBefore(localDateTime)
 
-#### Example
+##### Example
 
-	${localDateTime.isEqual(anotherlocalDateTime)}
-	${localDateTime.isAfter(anotherlocalDateTime)}
-	${localDateTime.isBefore(anotherlocalDateTime)}
+```freemarker
+${localDateTime.isEqual(anotherlocalDateTime)}
+${localDateTime.isAfter(anotherlocalDateTime)}
+${localDateTime.isBefore(anotherlocalDateTime)}
+```
 
-### :ballot_box_with_check: java.time.LocalTime
+#### :ballot_box_with_check: java.time.LocalTime
 
 Can compare two LocalTime objects for equality.
 
-#### Methods
+##### Methods
 
-* isEqual(localDateTime)
-* isAfter(localDateTime)
-* isBefore(localDateTime)
+- isEqual(localDateTime)
+- isAfter(localDateTime)
+- isBefore(localDateTime)
 
-#### Example
+##### Example
 
-	${localTime.isEqual(anotherlocalTime)}
-	${localTime.isAfter(anotherlocalTime)}
-	${localTime.isBefore(anotherlocalTime)}
+```freemarker
+${localTime.isEqual(anotherlocalTime)}
+${localTime.isAfter(anotherlocalTime)}
+${localTime.isBefore(anotherlocalTime)}
+```
 
-## Manipulating time
+### Manipulating time
 
-### :ballot_box_with_check: java.time.temporal.Temporal
+#### :ballot_box_with_check: java.time.temporal.Temporal
 
-Can create a new Temporal object with specified time difference from the original object, supporting 
+Can create a new Temporal object with specified time difference from the original object, supporting
 
-	java.time.Instant, 
-	java.time.LocalDate, 
-	java.time.LocalDateTime, 
-	java.time.LocalTime, 
-	java.time.OffsetDateTime, 
-	java.time.OffsetTime, 
-	java.time.Year, 
-	java.time.YearMonth, 
-	java.time.ZonedDateTime
- 
-#### Methods
+```freemarker
+java.time.Instant, 
+java.time.LocalDate, 
+java.time.LocalDateTime, 
+java.time.LocalTime, 
+java.time.OffsetDateTime, 
+java.time.OffsetTime, 
+java.time.Year, 
+java.time.YearMonth, 
+java.time.ZonedDateTime
+```
 
-* plusSeconds(<Long>)
-* plusMinutes(<Long>)
-* plusDays(<Long>)
-* plusWeeks(<Long>)
-* plusMonths(<Long>)
-* plusYears(<Long>)
-	
-#### Example
+##### Methods
 
-	${localDateTime.plusMonths(1).plus.Hours(-2).plusMinutes(5).plusSeconds(30).format()}
+- plusSeconds(long)
+- plusMinutes(long)
+- plusDays(long)
+- plusWeeks(long)
+- plusMonths(long)
+- plusYears(lone)
 
-## Notice
+##### Example
 
-
-Recently this repository was moved from the Amedia organisation to my
-private account on Github. The reason behind this is that I recently
-left Amedia after 13 years (!) and that they let me take this project
-with me. The package naming will however stay the same.
-
+```freemarker
+${localDateTime.plusMonths(1).plus.Hours(-2).plusMinutes(5).plusSeconds(30).format()}
+```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,18 @@
+# Upgrade guide
+
+## Upgrade from 1.3 to 2.0
+
+The 2.0 release addresses two major issues reported by users ([#18](https://github.com/lazee/freemarker-java-8/issues/18)/[#16](https://github.com/lazee/freemarker-java-8/issues/16)). It also introduces a new feature for manipulating time ([\#28](https://github.com/lazee/freemarker-java-8/pull/28)).  
+
+The upgrade itself is nothing else than changing the version in your build configuration (pom.xml or something else). However if you need to stick to the old behaviour on how time zones are treated when formatting ZonedDateTime objects, then you need to add a second argument to Java8ObjectWrapper upon initialization:
+
+```java
+configuration.setObjectWrapper(new Java8ObjectWrapper(VERSION_2_3_23, new EnvironmentTimeStrategy());
+```
+
+### Notice
+
+Recently this repository was moved from the Amedia organisation to my
+private account on Github. The reason behind this is that I recently
+left Amedia after 13 years (!) and that they let me take this project
+with me. The package naming will however stay the same.

--- a/src/main/java/no/api/freemarker/java8/Java8ObjectWrapper.java
+++ b/src/main/java/no/api/freemarker/java8/Java8ObjectWrapper.java
@@ -16,45 +16,13 @@
 
 package no.api.freemarker.java8;
 
-import freemarker.template.DefaultObjectWrapper;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.Version;
-import no.api.freemarker.java8.time.ClockAdapter;
-import no.api.freemarker.java8.time.DurationAdapter;
-import no.api.freemarker.java8.time.InstantAdapter;
-import no.api.freemarker.java8.time.LocalDateAdapter;
-import no.api.freemarker.java8.time.LocalDateTimeAdapter;
-import no.api.freemarker.java8.time.LocalTimeAdapter;
-import no.api.freemarker.java8.time.MonthDayAdapter;
-import no.api.freemarker.java8.time.OffsetDateTimeAdapter;
-import no.api.freemarker.java8.time.OffsetTimeAdapter;
-import no.api.freemarker.java8.time.PeriodAdapter;
-import no.api.freemarker.java8.time.TemporalDialerAdapter;
-import no.api.freemarker.java8.time.YearAdapter;
-import no.api.freemarker.java8.time.YearMonthAdapter;
-import no.api.freemarker.java8.time.ZoneIdAdapter;
-import no.api.freemarker.java8.time.ZoneOffsetAdapter;
-import no.api.freemarker.java8.time.ZonedDateTimeAdapter;
-import no.api.freemarker.java8.zone.KeepingZonedDateTimeStrategy;
+import freemarker.template.*;
+import no.api.freemarker.java8.time.*;
+import no.api.freemarker.java8.zone.KeepingZoneStrategy;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 import no.api.freemarker.java8.zone.ZonedDateTimeStrategy;
 
-import java.time.Clock;
-import java.time.Duration;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.MonthDay;
-import java.time.OffsetDateTime;
-import java.time.OffsetTime;
-import java.time.Period;
-import java.time.Year;
-import java.time.YearMonth;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.time.temporal.Temporal;
 
 /**
@@ -62,22 +30,27 @@ import java.time.temporal.Temporal;
  */
 public class Java8ObjectWrapper extends DefaultObjectWrapper {
 
-    private ZonedDateTimeStrategy strategy;
-
+    private ZoneStrategy strategy;
 
     public Java8ObjectWrapper(Version incompatibleImprovements) {
         super(incompatibleImprovements);
-        this.strategy = new KeepingZonedDateTimeStrategy();
+        this.strategy = new KeepingZoneStrategy();
     }
 
-
-    public Java8ObjectWrapper(Version incompatibleImprovements, ZonedDateTimeStrategy strategy) {
+    public Java8ObjectWrapper(Version incompatibleImprovements, ZoneStrategy strategy) {
         super(incompatibleImprovements);
         this.strategy = strategy;
     }
 
-
+    /**
+     * @deprecated Use {@link Java8ObjectWrapper#setZoneStrategy(ZoneStrategy)} instead.
+     */
+    @Deprecated
     public void setZonedDateTimeStrategy(ZonedDateTimeStrategy strategy) {
+        this.strategy = strategy;
+    }
+
+    public void setZoneStrategy(ZoneStrategy strategy) {
         this.strategy = strategy;
     }
 
@@ -85,41 +58,41 @@ public class Java8ObjectWrapper extends DefaultObjectWrapper {
     protected TemplateModel handleUnknownType(Object obj) throws TemplateModelException {
         TemplateModel delegate = _handleUnknownType(obj);
         return obj instanceof Temporal && delegate instanceof TemplateHashModel
-                ? new TemporalDialerAdapter((Temporal) obj, this, (TemplateHashModel) delegate)
-                : delegate;
+              ? new TemporalDialerAdapter((Temporal) obj, this, (TemplateHashModel) delegate, strategy)
+              : delegate;
     }
 
     private TemplateModel _handleUnknownType(Object obj) throws TemplateModelException {
         if (obj instanceof Clock) {
-            return new ClockAdapter((Clock) obj, this);
+            return new ClockAdapter((Clock) obj, this, strategy);
         } else if (obj instanceof Duration) {
-            return new DurationAdapter((Duration) obj, this);
+            return new DurationAdapter((Duration) obj, this, strategy);
         } else if (obj instanceof Instant) {
-            return new InstantAdapter((Instant) obj, this);
+            return new InstantAdapter((Instant) obj, this, strategy);
         } else if (obj instanceof LocalDate) {
-            return new LocalDateAdapter((LocalDate) obj, this);
+            return new LocalDateAdapter((LocalDate) obj, this, strategy);
         } else if (obj instanceof LocalDateTime) {
-            return new LocalDateTimeAdapter((LocalDateTime) obj, this);
+            return new LocalDateTimeAdapter((LocalDateTime) obj, this, strategy);
         } else if (obj instanceof LocalTime) {
-            return new LocalTimeAdapter((LocalTime) obj, this);
+            return new LocalTimeAdapter((LocalTime) obj, this, strategy);
         } else if (obj instanceof MonthDay) {
-            return new MonthDayAdapter((MonthDay) obj, this);
+            return new MonthDayAdapter((MonthDay) obj, this, strategy);
         } else if (obj instanceof OffsetDateTime) {
-            return new OffsetDateTimeAdapter((OffsetDateTime) obj, this);
+            return new OffsetDateTimeAdapter((OffsetDateTime) obj, this, strategy);
         } else if (obj instanceof OffsetTime) {
-            return new OffsetTimeAdapter((OffsetTime) obj, this);
+            return new OffsetTimeAdapter((OffsetTime) obj, this, strategy);
         } else if (obj instanceof Period) {
-            return new PeriodAdapter((Period) obj, this);
+            return new PeriodAdapter((Period) obj, this, strategy);
         } else if (obj instanceof Year) {
-            return new YearAdapter((Year) obj, this);
+            return new YearAdapter((Year) obj, this, strategy);
         } else if (obj instanceof YearMonth) {
-            return new YearMonthAdapter((YearMonth) obj, this);
+            return new YearMonthAdapter((YearMonth) obj, this, strategy);
         } else if (obj instanceof ZonedDateTime) {
             return new ZonedDateTimeAdapter((ZonedDateTime) obj, this, strategy);
         } else if (obj instanceof ZoneOffset) {
-            return new ZoneOffsetAdapter((ZoneOffset) obj, this);
+            return new ZoneOffsetAdapter((ZoneOffset) obj, this, strategy);
         } else if (obj instanceof ZoneId) {
-            return new ZoneIdAdapter((ZoneId) obj, this);
+            return new ZoneIdAdapter((ZoneId) obj, this, strategy);
         }
         return super.handleUnknownType(obj);
     }

--- a/src/main/java/no/api/freemarker/java8/time/AbstractAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/AbstractAdapter.java
@@ -18,11 +18,8 @@ package no.api.freemarker.java8.time;
 
 import freemarker.ext.beans.BeanModel;
 import freemarker.ext.beans.BeansWrapper;
-import freemarker.template.AdapterTemplateModel;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.WrappingTemplateModel;
+import freemarker.template.*;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 
 import java.util.Objects;
 
@@ -32,33 +29,30 @@ import java.util.Objects;
  * @param <E> The java.time class that this TemplateModel is wrapping.
  */
 public abstract class AbstractAdapter<E>
-        extends WrappingTemplateModel
-        implements AdapterTemplateModel, TemplateHashModel {
+      extends WrappingTemplateModel
+      implements AdapterTemplateModel, TemplateHashModel {
 
-    private E entity;
-
+    private final E entity;
     private final BeanModel fallback;
+    private final ZoneStrategy strategy;
 
 
-    public AbstractAdapter(E entity, BeansWrapper wrapper) {
+    public AbstractAdapter(E entity, BeansWrapper wrapper, ZoneStrategy strategy) {
         this.entity = entity;
+        this.strategy = strategy;
         this.fallback = new BeanModel(entity, Objects.requireNonNull(wrapper, "wrapper"));
     }
 
-
     protected abstract TemplateModel getForType(String key) throws TemplateModelException;
 
-
-    public String getAsString() throws TemplateModelException {
+    public String getAsString() {
         return getObject().toString();
     }
-
 
     @Override
     public Object getAdaptedObject(Class aClass) {
         return entity;
     }
-
 
     @Override
     public final TemplateModel get(final String key) throws TemplateModelException {
@@ -74,15 +68,16 @@ public abstract class AbstractAdapter<E>
         }
     }
 
-
     @Override
-    public boolean isEmpty() throws TemplateModelException {
+    public boolean isEmpty() {
         return false;
     }
-
 
     public E getObject() {
         return entity;
     }
 
+    public ZoneStrategy getStrategy() {
+        return strategy;
+    }
 }

--- a/src/main/java/no/api/freemarker/java8/time/AbstractAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/AbstractAdapter.java
@@ -36,7 +36,6 @@ public abstract class AbstractAdapter<E>
     private final BeanModel fallback;
     private final ZoneStrategy strategy;
 
-
     public AbstractAdapter(E entity, BeansWrapper wrapper, ZoneStrategy strategy) {
         this.entity = entity;
         this.strategy = strategy;

--- a/src/main/java/no/api/freemarker/java8/time/AbstractChecker.java
+++ b/src/main/java/no/api/freemarker/java8/time/AbstractChecker.java
@@ -9,13 +9,11 @@ package no.api.freemarker.java8.time;
  */
 public abstract class AbstractChecker<E> {
 
-    private E obj;
-
+    private final E obj;
 
     public AbstractChecker(E obj) {
         this.obj = obj;
     }
-
 
     public E getObject() {
         return obj;

--- a/src/main/java/no/api/freemarker/java8/time/AbstractFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/AbstractFormatter.java
@@ -44,6 +44,7 @@ public abstract class AbstractFormatter<E> {
 
     /**
      * Get the <code>java.time</code> object that should be formated.
+     *
      * @return Some <code>java.time</code> object.
      */
     public E getObject() {
@@ -59,7 +60,10 @@ public abstract class AbstractFormatter<E> {
         return strategy;
     }
 
-    public ZoneId getTargetZoneId(final List argumentList) throws TemplateModelException {
-        return zoneIdLookup(argumentList, 1).orElse(getStrategy().getZoneId());
+    public ZoneId getTargetZoneId(final List argumentList, ZoneId zoneId) throws TemplateModelException {
+        if (zoneId == null) {
+            return zoneIdLookup(argumentList, 1).orElse(getStrategy().getZoneId());
+        }
+        return zoneIdLookup(argumentList, 1).orElse(getStrategy().getZoneId(zoneId));
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/AbstractFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/AbstractFormatter.java
@@ -16,24 +16,50 @@
 
 package no.api.freemarker.java8.time;
 
+import freemarker.template.TemplateModelException;
+import no.api.freemarker.java8.zone.ZoneStrategy;
+
+import java.time.ZoneId;
+import java.util.List;
+
+import static no.api.freemarker.java8.time.DateTimeTools.zoneIdLookup;
+
 /**
  * Abstract formatter class.
  * <p>
  * Adapters supporting formatters will extend this class.
  *
- * @param <E> The java.time class this formatter handles.
+ * @param <E> The <code>java.time</code> class this formatter handles.
  */
 public abstract class AbstractFormatter<E> {
 
-    private E obj;
+    private final E obj;
 
+    private final ZoneStrategy strategy;
 
-    public AbstractFormatter(E obj) {
+    public AbstractFormatter(E obj, ZoneStrategy strategy) {
         this.obj = obj;
+        this.strategy = strategy;
     }
 
-
+    /**
+     * Get the <code>java.time</code> object that should be formated.
+     * @return Some <code>java.time</code> object.
+     */
     public E getObject() {
         return obj;
+    }
+
+    /**
+     * Get the Zone strategy to be used when formatting the object.
+     *
+     * @return The active zone strategy.
+     */
+    public ZoneStrategy getStrategy() {
+        return strategy;
+    }
+
+    public ZoneId getTargetZoneId(final List argumentList) throws TemplateModelException {
+        return zoneIdLookup(argumentList, 1).orElse(getStrategy().getZoneId());
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/AbstractMutator.java
+++ b/src/main/java/no/api/freemarker/java8/time/AbstractMutator.java
@@ -2,15 +2,14 @@ package no.api.freemarker.java8.time;
 
 /**
  * Abstract mutator class.
- *
+ * <p>
  * Adapters supporting mutators will extend this class.
  *
- * @param <E>
- *         The java.time class this mutator handles.
+ * @param <E> The <code>java.time</code> class this mutator handles.
  */
 public abstract class AbstractMutator<E> {
 
-    private E obj;
+    private final E obj;
 
     public AbstractMutator(E obj) {
         this.obj = obj;

--- a/src/main/java/no/api/freemarker/java8/time/AbstractTextStyleLocaleFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/AbstractTextStyleLocaleFormatter.java
@@ -25,9 +25,8 @@ import java.util.Locale;
 public class AbstractTextStyleLocaleFormatter<E> extends AbstractFormatter<E> {
 
     public AbstractTextStyleLocaleFormatter(E obj) {
-        super(obj);
+        super(obj, null);
     }
-
 
     public TextStyle findTextStyle(List list) {
         if (list.size() > 0) {
@@ -35,7 +34,6 @@ public class AbstractTextStyleLocaleFormatter<E> extends AbstractFormatter<E> {
         }
         return TextStyle.FULL;
     }
-
 
     public Locale findLocale(List list) {
         if (list.size() > 1) {

--- a/src/main/java/no/api/freemarker/java8/time/ClockAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/ClockAdapter.java
@@ -17,60 +17,40 @@
 package no.api.freemarker.java8.time;
 
 import freemarker.ext.beans.BeansWrapper;
-import freemarker.template.AdapterTemplateModel;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateMethodModelEx;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateScalarModel;
+import freemarker.template.*;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 
 import java.time.Clock;
-import java.util.List;
 
-import static no.api.freemarker.java8.time.DateTimeTools.*;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_FORMAT;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_UNKNOWN_MSG;
 
 /**
  * ClockAdapter adds basic format support for {@link Clock} too FreeMarker 2.3.23 and above.
  */
-public class ClockAdapter extends AbstractAdapter<Clock> implements AdapterTemplateModel,
-        TemplateScalarModel, TemplateHashModel {
+public class ClockAdapter extends AbstractAdapter<Clock> implements AdapterTemplateModel, TemplateScalarModel,
+      TemplateHashModel {
 
-    public ClockAdapter(Clock obj, BeansWrapper wrapper) {
-        super(obj, wrapper);
+    public ClockAdapter(Clock obj, BeansWrapper wrapper, ZoneStrategy strategy) {
+        super(obj, wrapper, strategy);
     }
-
 
     @Override
     public TemplateModel getForType(String s) throws TemplateModelException {
         if (METHOD_FORMAT.equals(s)) {
-            return new ClockFormatter(getObject());
+            return new ClockFormatter(getObject(), getStrategy());
         }
         throw new TemplateModelException(METHOD_UNKNOWN_MSG + s);
     }
-
 
     /**
      * This is a quit silly implementation. Normally you would like to convert to an Instant when printing the clock.
      *
      * @return String representation of the clock.
-     * @throws TemplateModelException If no string representation could be created.
      */
     @Override
-    public String getAsString() throws TemplateModelException {
+    public String getAsString() {
         return getObject().toString();
     }
 
-
-    public class ClockFormatter extends AbstractFormatter<Clock> implements TemplateMethodModelEx {
-
-        public ClockFormatter(Clock obj) {
-            super(obj);
-        }
-
-
-        @Override
-        public Object exec(List list) throws TemplateModelException {
-            return getObject().toString();
-        }
-    }
 }

--- a/src/main/java/no/api/freemarker/java8/time/ClockAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/ClockAdapter.java
@@ -43,11 +43,6 @@ public class ClockAdapter extends AbstractAdapter<Clock> implements AdapterTempl
         throw new TemplateModelException(METHOD_UNKNOWN_MSG + s);
     }
 
-    /**
-     * This is a quit silly implementation. Normally you would like to convert to an Instant when printing the clock.
-     *
-     * @return String representation of the clock.
-     */
     @Override
     public String getAsString() {
         return getObject().toString();

--- a/src/main/java/no/api/freemarker/java8/time/ClockFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/ClockFormatter.java
@@ -1,0 +1,26 @@
+package no.api.freemarker.java8.time;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
+import no.api.freemarker.java8.zone.ZoneStrategy;
+
+import java.time.Clock;
+import java.util.List;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
+
+public class ClockFormatter extends AbstractFormatter<Clock> implements TemplateMethodModelEx {
+
+    public ClockFormatter(Clock obj, ZoneStrategy strategy) {
+        super(obj, strategy);
+    }
+
+    @Override
+    public Object exec(List list) throws TemplateModelException {
+        return createDateTimeFormatter(list, 0, ISO_LOCAL_DATE)
+              .withZone(getTargetZoneId(list))
+              .format(getObject().instant());
+    }
+
+}

--- a/src/main/java/no/api/freemarker/java8/time/ClockFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/ClockFormatter.java
@@ -7,7 +7,7 @@ import no.api.freemarker.java8.zone.ZoneStrategy;
 import java.time.Clock;
 import java.util.List;
 
-import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
 
 public class ClockFormatter extends AbstractFormatter<Clock> implements TemplateMethodModelEx {
@@ -18,8 +18,8 @@ public class ClockFormatter extends AbstractFormatter<Clock> implements Template
 
     @Override
     public Object exec(List list) throws TemplateModelException {
-        return createDateTimeFormatter(list, 0, ISO_LOCAL_DATE)
-              .withZone(getTargetZoneId(list))
+        return createDateTimeFormatter(list, 0, ISO_LOCAL_DATE_TIME)
+              .withZone(getTargetZoneId(list, null))
               .format(getObject().instant());
     }
 

--- a/src/main/java/no/api/freemarker/java8/time/DateTimeTools.java
+++ b/src/main/java/no/api/freemarker/java8/time/DateTimeTools.java
@@ -47,11 +47,9 @@ public final class DateTimeTools {
     public static final String METHOD_UNKNOWN_MSG = "Unknown method call: ";
     public static final String ILLEGAL_ZONE_ID_MSG = "Illegal Zone ID";
 
-
     private DateTimeTools() {
         throw new UnsupportedOperationException();
     }
-
 
     /**
      * Create a DateTimeFormatter from a pattern found in a List on a given index.
@@ -61,8 +59,10 @@ public final class DateTimeTools {
      * @param defaultFormatter A default formatter to be returned if the given list size is lower than the given index.
      * @return A DateTimeFormatter for the given pattern, or the default formatter.
      */
-    public static DateTimeFormatter createDateTimeFormatter(final List list, final int index,
-                                                            final DateTimeFormatter defaultFormatter) {
+    public static DateTimeFormatter createDateTimeFormatter(
+          final List list, final int index,
+          final DateTimeFormatter defaultFormatter
+    ) {
         if (list.size() > 0) {
             final String format = ((SimpleScalar) list.get(index)).getAsString();
             final ExtFormatStyle style = DateTimeTools.getFormatStyle(format);
@@ -76,7 +76,6 @@ public final class DateTimeTools {
         return defaultFormatter.withLocale(DateTimeTools.getLocale());
     }
 
-
     /**
      * Create a DateTimeFormatter from a pattern found in a List on a given index.
      *
@@ -85,22 +84,24 @@ public final class DateTimeTools {
      * @param defaultPattern The pattern to be used for the formatter if the list size is lower than the given index.
      * @return A DateTimeFormatter for the given pattern, or the default pattern.
      */
-    public static DateTimeFormatter createDateTimeFormatter(List list,
-                                                            int index,
-                                                            final String defaultPattern) {
+    public static DateTimeFormatter createDateTimeFormatter(
+          List list,
+          int index,
+          final String defaultPattern
+    ) {
         return DateTimeFormatter.ofPattern(
-                list.size() > index
-                        ? ((SimpleScalar) list.get(index)).getAsString()
-                        : defaultPattern, getLocale());
+              list.size() > index
+                    ? ((SimpleScalar) list.get(index)).getAsString()
+                    : defaultPattern, getLocale());
     }
-
 
     /**
      * Look up a ZoneId based on a String in a list on a given index.
      *
      * @param list  A list of Strings containing the String representation of the ZoneId.
      * @param index The index on where in the list the ZoneId string is located.
-     * @return A ZoneId instance for the given ZoneId string. If index is lower than the list size, then an empty {@link Optional} will be returned.
+     * @return A ZoneId instance for the given ZoneId string. If index is lower than the list size, then an empty
+     * {@link Optional} will be returned.
      * @throws TemplateModelException If Illegal ZoneId string was found in the list.
      */
     public static Optional<ZoneId> zoneIdLookup(final List list, final int index) throws TemplateModelException {
@@ -115,7 +116,6 @@ public final class DateTimeTools {
         return Optional.empty();
     }
 
-
     private static Locale getLocale() {
         if (Environment.getCurrentEnvironment() != null) {
             return Environment.getCurrentEnvironment().getLocale();
@@ -123,7 +123,6 @@ public final class DateTimeTools {
             return Locale.getDefault();
         }
     }
-
 
     private static ExtFormatStyle getFormatStyle(final String format) {
         try {
@@ -133,18 +132,17 @@ public final class DateTimeTools {
         }
     }
 
-
     private static Optional<DateTimeFormatter> getJreBuiltinFormatter(final String name) {
         try {
             final Field dateTimeFormatterField = DateTimeFormatter.class.getField(name);
             if ((dateTimeFormatterField.getModifiers() & Modifier.STATIC) != 0 // Check if field is static
-                    && DateTimeFormatter.class.isAssignableFrom(dateTimeFormatterField.getType())) {
+                  && DateTimeFormatter.class.isAssignableFrom(dateTimeFormatterField.getType())) {
                 return Optional.ofNullable((DateTimeFormatter) dateTimeFormatterField.get(null));
             }
             // Not static, or not of the correct type
             return Optional.empty();
         } catch (final NoSuchFieldException e) {
-            // Seems like name is no built in DateTimeFormatter
+            // Seems like name is no built-in DateTimeFormatter
             return Optional.empty();
         } catch (final IllegalArgumentException e) {
             // As this field is checked to be static, this should never occur
@@ -152,7 +150,7 @@ public final class DateTimeTools {
         } catch (final IllegalAccessException e) {
             // Well, if you use a SecurityManager, we cannot do this
             throw new RuntimeException(
-                    "Not allowed to access Field \"" + name + "\" of class " + DateTimeFormatter.class, e);
+                  "Not allowed to access Field \"" + name + "\" of class " + DateTimeFormatter.class, e);
         }
     }
 

--- a/src/main/java/no/api/freemarker/java8/time/DateTimeTools.java
+++ b/src/main/java/no/api/freemarker/java8/time/DateTimeTools.java
@@ -43,6 +43,7 @@ public final class DateTimeTools {
     public static final String METHOD_YEARS = "years";
     public static final String METHOD_NANO = "nano";
     public static final String METHOD_SECONDS = "seconds";
+    public static final String METHOD_AS_ZONE_DATETIME = "toZonedDateTime";
 
     public static final String METHOD_UNKNOWN_MSG = "Unknown method call: ";
     public static final String ILLEGAL_ZONE_ID_MSG = "Illegal Zone ID";
@@ -70,6 +71,7 @@ public final class DateTimeTools {
             if (style != null) {
                 return style.getFormatter().withLocale(DateTimeTools.getLocale());
             }
+
             final Optional<DateTimeFormatter> builtin = DateTimeTools.getJreBuiltinFormatter(format);
             return builtin.orElseGet(() -> DateTimeFormatter.ofPattern(format, DateTimeTools.getLocale()));
         }

--- a/src/main/java/no/api/freemarker/java8/time/DurationAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/DurationAdapter.java
@@ -17,12 +17,8 @@
 package no.api.freemarker.java8.time;
 
 import freemarker.ext.beans.BeansWrapper;
-import freemarker.template.AdapterTemplateModel;
-import freemarker.template.SimpleNumber;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateScalarModel;
+import freemarker.template.*;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 
 import java.time.Duration;
 
@@ -32,12 +28,11 @@ import static no.api.freemarker.java8.time.DateTimeTools.*;
  * DurationAdapter adds basic format support for {@link Duration} too FreeMarker 2.3.23 and above.
  */
 public class DurationAdapter extends AbstractAdapter<Duration> implements AdapterTemplateModel,
-        TemplateScalarModel, TemplateHashModel {
+      TemplateScalarModel, TemplateHashModel {
 
-    public DurationAdapter(Duration obj, BeansWrapper wrapper) {
-        super(obj, wrapper);
+    public DurationAdapter(Duration obj, BeansWrapper wrapper, ZoneStrategy strategy) {
+        super(obj, wrapper, strategy);
     }
-
 
     @Override
     public TemplateModel getForType(String s) throws TemplateModelException {

--- a/src/main/java/no/api/freemarker/java8/time/InstantAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/InstantAdapter.java
@@ -17,49 +17,30 @@
 package no.api.freemarker.java8.time;
 
 import freemarker.ext.beans.BeansWrapper;
-import freemarker.template.AdapterTemplateModel;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateMethodModelEx;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateScalarModel;
+import freemarker.template.*;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 
 import java.time.Instant;
-import java.util.List;
 
-import static no.api.freemarker.java8.time.DateTimeTools.*;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_FORMAT;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_UNKNOWN_MSG;
 
 /**
  * InstantAdapter adds basic format support for {@link Instant} too FreeMarker 2.3.23 and above.
  */
 public class InstantAdapter extends AbstractAdapter<Instant> implements AdapterTemplateModel,
-        TemplateScalarModel, TemplateHashModel {
+      TemplateScalarModel, TemplateHashModel {
 
-
-    public InstantAdapter(Instant obj, BeansWrapper wrapper) {
-        super(obj, wrapper);
+    public InstantAdapter(Instant obj, BeansWrapper wrapper, ZoneStrategy strategy) {
+        super(obj, wrapper, strategy);
     }
-
 
     @Override
     public TemplateModel getForType(String s) throws TemplateModelException {
         if (METHOD_FORMAT.equals(s)) {
-            return new InstantFormatter(getObject());
+            return new InstantFormatter(getObject(), getStrategy());
         }
         throw new TemplateModelException(METHOD_UNKNOWN_MSG + s);
     }
 
-
-    public class InstantFormatter extends AbstractFormatter<Instant> implements TemplateMethodModelEx {
-
-        public InstantFormatter(Instant obj) {
-            super(obj);
-        }
-
-
-        @Override
-        public Object exec(List list) throws TemplateModelException {
-            return getObject().toString();
-        }
-    }
 }

--- a/src/main/java/no/api/freemarker/java8/time/InstantFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/InstantFormatter.java
@@ -7,7 +7,7 @@ import no.api.freemarker.java8.zone.ZoneStrategy;
 import java.time.Instant;
 import java.util.List;
 
-import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
 
 public class InstantFormatter extends AbstractFormatter<Instant> implements TemplateMethodModelEx {
@@ -18,8 +18,8 @@ public class InstantFormatter extends AbstractFormatter<Instant> implements Temp
 
     @Override
     public Object exec(List list) throws TemplateModelException {
-        return createDateTimeFormatter(list, 0, ISO_LOCAL_DATE)
-              .withZone(getTargetZoneId(list))
+        return createDateTimeFormatter(list, 0, ISO_LOCAL_DATE_TIME)
+              .withZone(getTargetZoneId(list, null))
               .format(getObject());
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/InstantFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/InstantFormatter.java
@@ -1,0 +1,25 @@
+package no.api.freemarker.java8.time;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
+import no.api.freemarker.java8.zone.ZoneStrategy;
+
+import java.time.Instant;
+import java.util.List;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
+
+public class InstantFormatter extends AbstractFormatter<Instant> implements TemplateMethodModelEx {
+
+    public InstantFormatter(Instant obj, ZoneStrategy strategy) {
+        super(obj, strategy);
+    }
+
+    @Override
+    public Object exec(List list) throws TemplateModelException {
+        return createDateTimeFormatter(list, 0, ISO_LOCAL_DATE)
+              .withZone(getTargetZoneId(list))
+              .format(getObject());
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/time/LocalDateAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalDateAdapter.java
@@ -17,17 +17,10 @@
 package no.api.freemarker.java8.time;
 
 import freemarker.ext.beans.BeansWrapper;
-import freemarker.template.AdapterTemplateModel;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateMethodModelEx;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateScalarModel;
+import freemarker.template.*;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 
 import java.time.LocalDate;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
 
 import static no.api.freemarker.java8.time.DateTimeTools.*;
 
@@ -35,66 +28,20 @@ import static no.api.freemarker.java8.time.DateTimeTools.*;
  * LocalDateAdapter adds basic format support for {@link LocalDate} too FreeMarker 2.3.23 and above.
  */
 public class LocalDateAdapter extends AbstractAdapter<LocalDate> implements AdapterTemplateModel,
-        TemplateScalarModel, TemplateHashModel {
+      TemplateScalarModel, TemplateHashModel {
 
-    public LocalDateAdapter(LocalDate obj, BeansWrapper wrapper) {
-        super(obj, wrapper);
+    public LocalDateAdapter(LocalDate obj, BeansWrapper wrapper, ZoneStrategy strategy) {
+        super(obj, wrapper, strategy);
     }
-
 
     @Override
     public TemplateModel getForType(String s) throws TemplateModelException {
         if (METHOD_FORMAT.equals(s)) {
-            return new LocalDateFormatter(getObject());
+            return new LocalDateFormatter(getObject(), getStrategy());
         } else if (METHOD_EQUALS.equals(s) || METHOD_AFTER.equals(s) || METHOD_BEFORE.equals(s)) {
             return new LocalDateChecker(getObject(), s);
         }
         throw new TemplateModelException(METHOD_UNKNOWN_MSG + s);
     }
 
-
-    public class LocalDateFormatter extends AbstractFormatter<LocalDate> implements TemplateMethodModelEx {
-
-        public LocalDateFormatter(LocalDate obj) {
-            super(obj);
-        }
-
-
-        @Override
-        public Object exec(List list) throws TemplateModelException {
-            return getObject().format(createDateTimeFormatter(list, 0, DateTimeFormatter.ISO_LOCAL_DATE));
-        }
-    }
-
-    public class LocalDateChecker extends AbstractChecker<LocalDate> implements TemplateMethodModelEx {
-        private String method;
-
-
-        public LocalDateChecker(LocalDate obj, String method) {
-            super(obj);
-            this.method = method;
-        }
-
-
-        @SuppressWarnings("Duplicates")
-        @Override
-        public Object exec(List list) throws TemplateModelException {
-            AbstractAdapter adapter = (AbstractAdapter) list.get(0);
-            Object object = adapter.getObject();
-            if (object instanceof LocalDate) {
-                LocalDate other = (LocalDate) object;
-                switch (method) {
-                    case METHOD_EQUALS:
-                        return getObject().equals(other);
-                    case METHOD_AFTER:
-                        return getObject().isAfter(other);
-                    case METHOD_BEFORE:
-                        return getObject().isBefore(other);
-                }
-                throw new TemplateModelException("method not implemented");
-            } else {
-                throw new TemplateModelException("Invalid operand type for " + method + ": " + object);
-            }
-        }
-    }
 }

--- a/src/main/java/no/api/freemarker/java8/time/LocalDateChecker.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalDateChecker.java
@@ -1,0 +1,39 @@
+package no.api.freemarker.java8.time;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static no.api.freemarker.java8.time.DateTimeTools.*;
+
+public class LocalDateChecker extends AbstractChecker<LocalDate> implements TemplateMethodModelEx {
+    private final String method;
+
+    public LocalDateChecker(LocalDate obj, String method) {
+        super(obj);
+        this.method = method;
+    }
+
+    @SuppressWarnings("Duplicates")
+    @Override
+    public Object exec(List list) throws TemplateModelException {
+        AbstractAdapter adapter = (AbstractAdapter) list.get(0);
+        Object object = adapter.getObject();
+        if (object instanceof LocalDate) {
+            LocalDate other = (LocalDate) object;
+            switch (method) {
+                case METHOD_EQUALS:
+                    return getObject().equals(other);
+                case METHOD_AFTER:
+                    return getObject().isAfter(other);
+                case METHOD_BEFORE:
+                    return getObject().isBefore(other);
+            }
+            throw new TemplateModelException("method not implemented");
+        } else {
+            throw new TemplateModelException("Invalid operand type for " + method + ": " + object);
+        }
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/time/LocalDateFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalDateFormatter.java
@@ -1,0 +1,24 @@
+package no.api.freemarker.java8.time;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
+import no.api.freemarker.java8.zone.ZoneStrategy;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
+
+public class LocalDateFormatter extends AbstractFormatter<LocalDate> implements TemplateMethodModelEx {
+
+    public LocalDateFormatter(LocalDate obj, ZoneStrategy strategy) {
+        super(obj, strategy);
+    }
+
+    @Override
+    public Object exec(List list) throws TemplateModelException {
+        return getObject()
+              .format(createDateTimeFormatter(list, 0, ISO_LOCAL_DATE).withZone(getTargetZoneId(list)));
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/time/LocalDateFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalDateFormatter.java
@@ -19,6 +19,6 @@ public class LocalDateFormatter extends AbstractFormatter<LocalDate> implements 
     @Override
     public Object exec(List list) throws TemplateModelException {
         return getObject()
-              .format(createDateTimeFormatter(list, 0, ISO_LOCAL_DATE).withZone(getTargetZoneId(list)));
+              .format(createDateTimeFormatter(list, 0, ISO_LOCAL_DATE));
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/LocalDateTimeAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalDateTimeAdapter.java
@@ -17,16 +17,10 @@
 package no.api.freemarker.java8.time;
 
 import freemarker.ext.beans.BeansWrapper;
-import freemarker.template.AdapterTemplateModel;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateMethodModelEx;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateScalarModel;
+import freemarker.template.*;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
 
 import static no.api.freemarker.java8.time.DateTimeTools.*;
 
@@ -34,67 +28,19 @@ import static no.api.freemarker.java8.time.DateTimeTools.*;
  * LocalDateTimeAdapter adds basic format support for {@link LocalDateTime} too FreeMarker 2.3.23 and above.
  */
 public class LocalDateTimeAdapter extends AbstractAdapter<LocalDateTime> implements AdapterTemplateModel,
-        TemplateScalarModel, TemplateHashModel {
+      TemplateScalarModel, TemplateHashModel {
 
-
-    public LocalDateTimeAdapter(LocalDateTime obj, BeansWrapper wrapper) {
-        super(obj, wrapper);
+    public LocalDateTimeAdapter(LocalDateTime obj, BeansWrapper wrapper, ZoneStrategy strategy) {
+        super(obj, wrapper, strategy);
     }
-
 
     @Override
     public TemplateModel getForType(String s) throws TemplateModelException {
         if (METHOD_FORMAT.equals(s)) {
-            return new LocalDateTimeFormatter(getObject());
+            return new LocalDateTimeFormatter(getObject(), getStrategy());
         } else if (METHOD_EQUALS.equals(s) || METHOD_AFTER.equals(s) || METHOD_BEFORE.equals(s)) {
             return new LocalDateTimeChecker(getObject(), s);
         }
         throw new TemplateModelException(METHOD_UNKNOWN_MSG + s);
-    }
-
-
-    public class LocalDateTimeFormatter extends AbstractFormatter<LocalDateTime> implements TemplateMethodModelEx {
-
-        public LocalDateTimeFormatter(LocalDateTime obj) {
-            super(obj);
-        }
-
-
-        @Override
-        public Object exec(List list) throws TemplateModelException {
-            return getObject().format(createDateTimeFormatter(list, 0, DateTimeFormatter.ISO_LOCAL_DATE_TIME));
-        }
-    }
-
-    public class LocalDateTimeChecker extends AbstractChecker<LocalDateTime> implements TemplateMethodModelEx {
-        private String method;
-
-
-        public LocalDateTimeChecker(LocalDateTime obj, String method) {
-            super(obj);
-            this.method = method;
-        }
-
-
-        @SuppressWarnings("Duplicates")
-        @Override
-        public Object exec(List list) throws TemplateModelException {
-            AbstractAdapter adapter = (AbstractAdapter) list.get(0);
-            Object object = adapter.getObject();
-            if (object instanceof LocalDateTime) {
-                LocalDateTime other = (LocalDateTime) object;
-                switch (method) {
-                    case METHOD_EQUALS:
-                        return getObject().equals(other);
-                    case METHOD_AFTER:
-                        return getObject().isAfter(other);
-                    case METHOD_BEFORE:
-                        return getObject().isBefore(other);
-                }
-                throw new TemplateModelException("method not implemented");
-            } else {
-                throw new TemplateModelException("Invalid operand type for " + method + ": " + object);
-            }
-        }
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/LocalDateTimeAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalDateTimeAdapter.java
@@ -38,6 +38,8 @@ public class LocalDateTimeAdapter extends AbstractAdapter<LocalDateTime> impleme
     public TemplateModel getForType(String s) throws TemplateModelException {
         if (METHOD_FORMAT.equals(s)) {
             return new LocalDateTimeFormatter(getObject(), getStrategy());
+        } else if (METHOD_AS_ZONE_DATETIME.equals(s)) {
+            return new LocalDateTimeToZonedConverter(getObject(), getStrategy());
         } else if (METHOD_EQUALS.equals(s) || METHOD_AFTER.equals(s) || METHOD_BEFORE.equals(s)) {
             return new LocalDateTimeChecker(getObject(), s);
         }

--- a/src/main/java/no/api/freemarker/java8/time/LocalDateTimeChecker.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalDateTimeChecker.java
@@ -1,0 +1,39 @@
+package no.api.freemarker.java8.time;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static no.api.freemarker.java8.time.DateTimeTools.*;
+
+public class LocalDateTimeChecker extends AbstractChecker<LocalDateTime> implements TemplateMethodModelEx {
+    private final String method;
+
+    public LocalDateTimeChecker(LocalDateTime obj, String method) {
+        super(obj);
+        this.method = method;
+    }
+
+    @SuppressWarnings("Duplicates")
+    @Override
+    public Object exec(List list) throws TemplateModelException {
+        AbstractAdapter adapter = (AbstractAdapter) list.get(0);
+        Object object = adapter.getObject();
+        if (object instanceof LocalDateTime) {
+            LocalDateTime other = (LocalDateTime) object;
+            switch (method) {
+                case METHOD_EQUALS:
+                    return getObject().equals(other);
+                case METHOD_AFTER:
+                    return getObject().isAfter(other);
+                case METHOD_BEFORE:
+                    return getObject().isBefore(other);
+            }
+            throw new TemplateModelException("method not implemented");
+        } else {
+            throw new TemplateModelException("Invalid operand type for " + method + ": " + object);
+        }
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/time/LocalDateTimeFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalDateTimeFormatter.java
@@ -1,0 +1,23 @@
+package no.api.freemarker.java8.time;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
+import no.api.freemarker.java8.zone.ZoneStrategy;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
+
+public class LocalDateTimeFormatter extends AbstractFormatter<LocalDateTime> implements TemplateMethodModelEx {
+
+    public LocalDateTimeFormatter(LocalDateTime obj, ZoneStrategy strategy) {
+        super(obj, strategy);
+    }
+
+    @Override
+    public Object exec(List list) throws TemplateModelException {
+        return getObject().format(createDateTimeFormatter(list, 0, ISO_LOCAL_DATE_TIME).withZone(getTargetZoneId(list)));
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/time/LocalDateTimeFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalDateTimeFormatter.java
@@ -18,6 +18,6 @@ public class LocalDateTimeFormatter extends AbstractFormatter<LocalDateTime> imp
 
     @Override
     public Object exec(List list) throws TemplateModelException {
-        return getObject().format(createDateTimeFormatter(list, 0, ISO_LOCAL_DATE_TIME).withZone(getTargetZoneId(list)));
+        return getObject().format(createDateTimeFormatter(list, 0, ISO_LOCAL_DATE_TIME).withZone(getTargetZoneId(list, null)));
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/LocalDateTimeToZonedConverter.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalDateTimeToZonedConverter.java
@@ -1,0 +1,21 @@
+package no.api.freemarker.java8.time;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
+import no.api.freemarker.java8.zone.ZoneStrategy;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+public class LocalDateTimeToZonedConverter extends AbstractFormatter<LocalDateTime> implements TemplateMethodModelEx {
+
+    public LocalDateTimeToZonedConverter(LocalDateTime obj, ZoneStrategy strategy) {
+        super(obj, strategy);
+    }
+
+    @Override
+    public Object exec(List list) throws TemplateModelException {
+        return ZonedDateTime.of(getObject(), getTargetZoneId(list, null));
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/time/LocalTimeAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalTimeAdapter.java
@@ -17,16 +17,10 @@
 package no.api.freemarker.java8.time;
 
 import freemarker.ext.beans.BeansWrapper;
-import freemarker.template.AdapterTemplateModel;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateMethodModelEx;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateScalarModel;
+import freemarker.template.*;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
 
 import static no.api.freemarker.java8.time.DateTimeTools.*;
 
@@ -34,65 +28,20 @@ import static no.api.freemarker.java8.time.DateTimeTools.*;
  * LocalTimeAdapter adds basic format support for {@link LocalTime} too FreeMarker 2.3.23 and above.
  */
 public class LocalTimeAdapter extends AbstractAdapter<LocalTime> implements AdapterTemplateModel,
-        TemplateScalarModel, TemplateHashModel {
+      TemplateScalarModel, TemplateHashModel {
 
-    public LocalTimeAdapter(LocalTime obj, BeansWrapper wrapper) {
-        super(obj, wrapper);
+    public LocalTimeAdapter(LocalTime obj, BeansWrapper wrapper, ZoneStrategy strategy) {
+        super(obj, wrapper, strategy);
     }
-
 
     @Override
     public TemplateModel getForType(String s) throws TemplateModelException {
         if (METHOD_FORMAT.equals(s)) {
-            return new LocalTimeFormatter(getObject());
+            return new LocalTimeFormatter(getObject(), getStrategy());
         } else if (METHOD_EQUALS.equals(s) || METHOD_AFTER.equals(s) || METHOD_BEFORE.equals(s)) {
             return new LocalTimeChecker(getObject(), s);
         }
         throw new TemplateModelException(METHOD_UNKNOWN_MSG + s);
     }
 
-
-    public class LocalTimeFormatter extends AbstractFormatter<LocalTime> implements TemplateMethodModelEx {
-
-        public LocalTimeFormatter(LocalTime obj) {
-            super(obj);
-        }
-
-
-        @Override
-        public Object exec(List list) throws TemplateModelException {
-            return getObject().format(createDateTimeFormatter(list, 0, DateTimeFormatter.ISO_LOCAL_TIME));
-        }
-    }
-
-    public class LocalTimeChecker extends AbstractChecker<LocalTime> implements TemplateMethodModelEx {
-        private String method;
-
-
-        public LocalTimeChecker(LocalTime obj, String method) {
-            super(obj);
-            this.method = method;
-        }
-
-
-        @Override
-        public Object exec(List list) throws TemplateModelException {
-            AbstractAdapter adapter = (AbstractAdapter) list.get(0);
-            Object object = adapter.getObject();
-            if (object instanceof LocalTime) {
-                LocalTime other = (LocalTime) object;
-                switch (method) {
-                    case METHOD_EQUALS:
-                        return getObject().equals(other);
-                    case METHOD_AFTER:
-                        return getObject().isAfter(other);
-                    case METHOD_BEFORE:
-                        return getObject().isBefore(other);
-                }
-                throw new TemplateModelException("method not implemented");
-            } else {
-                throw new TemplateModelException("Invalid operand type for " + method + ": " + object);
-            }
-        }
-    }
 }

--- a/src/main/java/no/api/freemarker/java8/time/LocalTimeChecker.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalTimeChecker.java
@@ -1,0 +1,39 @@
+package no.api.freemarker.java8.time;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import static no.api.freemarker.java8.time.DateTimeTools.*;
+
+public class LocalTimeChecker extends AbstractChecker<LocalTime> implements TemplateMethodModelEx {
+    private final String method;
+
+    public LocalTimeChecker(LocalTime obj, String method) {
+        super(obj);
+        this.method = method;
+    }
+
+    @SuppressWarnings("DuplicatedCode")
+    @Override
+    public Object exec(List list) throws TemplateModelException {
+        AbstractAdapter adapter = (AbstractAdapter) list.get(0);
+        Object object = adapter.getObject();
+        if (object instanceof LocalTime) {
+            LocalTime other = (LocalTime) object;
+            switch (method) {
+                case METHOD_EQUALS:
+                    return getObject().equals(other);
+                case METHOD_AFTER:
+                    return getObject().isAfter(other);
+                case METHOD_BEFORE:
+                    return getObject().isBefore(other);
+            }
+            throw new TemplateModelException("method not implemented");
+        } else {
+            throw new TemplateModelException("Invalid operand type for " + method + ": " + object);
+        }
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/time/LocalTimeFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalTimeFormatter.java
@@ -18,6 +18,6 @@ public class LocalTimeFormatter extends AbstractFormatter<LocalTime> implements 
 
     @Override
     public Object exec(List list) throws TemplateModelException {
-        return getObject().format(createDateTimeFormatter(list, 0, ISO_LOCAL_TIME).withZone(getTargetZoneId(list)));
+        return getObject().format(createDateTimeFormatter(list, 0, ISO_LOCAL_TIME));
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/LocalTimeFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalTimeFormatter.java
@@ -1,0 +1,23 @@
+package no.api.freemarker.java8.time;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
+import no.api.freemarker.java8.zone.ZoneStrategy;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
+
+public class LocalTimeFormatter extends AbstractFormatter<LocalTime> implements TemplateMethodModelEx {
+
+    public LocalTimeFormatter(LocalTime obj, ZoneStrategy strategy) {
+        super(obj, strategy);
+    }
+
+    @Override
+    public Object exec(List list) throws TemplateModelException {
+        return getObject().format(createDateTimeFormatter(list, 0, ISO_LOCAL_TIME).withZone(getTargetZoneId(list)));
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/time/MonthDayAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/MonthDayAdapter.java
@@ -17,48 +17,29 @@
 package no.api.freemarker.java8.time;
 
 import freemarker.ext.beans.BeansWrapper;
-import freemarker.template.AdapterTemplateModel;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateMethodModelEx;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateScalarModel;
+import freemarker.template.*;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 
 import java.time.MonthDay;
-import java.util.List;
 
-import static no.api.freemarker.java8.time.DateTimeTools.*;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_FORMAT;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_UNKNOWN_MSG;
 
 /**
  * MonthDayAdapter adds basic format support for {@link MonthDay} too FreeMarker 2.3.23 and above.
  */
 public class MonthDayAdapter extends AbstractAdapter<MonthDay> implements AdapterTemplateModel,
-        TemplateScalarModel, TemplateHashModel {
+      TemplateScalarModel, TemplateHashModel {
 
-    public MonthDayAdapter(MonthDay obj, BeansWrapper wrapper) {
-        super(obj, wrapper);
+    public MonthDayAdapter(MonthDay obj, BeansWrapper wrapper, ZoneStrategy strategy) {
+        super(obj, wrapper, strategy);
     }
-
 
     @Override
     public TemplateModel getForType(String s) throws TemplateModelException {
         if (METHOD_FORMAT.equals(s)) {
-            return new MonthDayFormatter(getObject());
+            return new MonthDayFormatter(getObject(), getStrategy());
         }
         throw new TemplateModelException(METHOD_UNKNOWN_MSG + s);
-    }
-
-
-    public class MonthDayFormatter extends AbstractFormatter<MonthDay> implements TemplateMethodModelEx {
-
-        public MonthDayFormatter(MonthDay obj) {
-            super(obj);
-        }
-
-
-        @Override
-        public Object exec(List list) throws TemplateModelException {
-            return getObject().format(createDateTimeFormatter(list, 0, "MM:dd"));
-        }
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/MonthDayFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/MonthDayFormatter.java
@@ -17,6 +17,6 @@ public class MonthDayFormatter extends AbstractFormatter<MonthDay> implements Te
 
     @Override
     public Object exec(List list) throws TemplateModelException {
-        return getObject().format(createDateTimeFormatter(list, 0, "MM:dd").withZone(getTargetZoneId(list)));
+        return getObject().format(createDateTimeFormatter(list, 0, "MM:dd"));
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/MonthDayFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/MonthDayFormatter.java
@@ -1,0 +1,22 @@
+package no.api.freemarker.java8.time;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
+import no.api.freemarker.java8.zone.ZoneStrategy;
+
+import java.time.MonthDay;
+import java.util.List;
+
+import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
+
+public class MonthDayFormatter extends AbstractFormatter<MonthDay> implements TemplateMethodModelEx {
+
+    public MonthDayFormatter(MonthDay obj, ZoneStrategy strategy) {
+        super(obj, strategy);
+    }
+
+    @Override
+    public Object exec(List list) throws TemplateModelException {
+        return getObject().format(createDateTimeFormatter(list, 0, "MM:dd").withZone(getTargetZoneId(list)));
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/time/OffsetDateTimeAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/OffsetDateTimeAdapter.java
@@ -17,49 +17,29 @@
 package no.api.freemarker.java8.time;
 
 import freemarker.ext.beans.BeansWrapper;
-import freemarker.template.AdapterTemplateModel;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateMethodModelEx;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateScalarModel;
+import freemarker.template.*;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
 
-import static no.api.freemarker.java8.time.DateTimeTools.*;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_FORMAT;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_UNKNOWN_MSG;
 
 /**
  * OffsetDateTimeAdapter adds basic format support for {@link OffsetDateTime} too FreeMarker 2.3.23 and above.
  */
 public class OffsetDateTimeAdapter extends AbstractAdapter<OffsetDateTime> implements AdapterTemplateModel,
-        TemplateScalarModel, TemplateHashModel {
+      TemplateScalarModel, TemplateHashModel {
 
-    public OffsetDateTimeAdapter(OffsetDateTime obj, BeansWrapper wrapper) {
-        super(obj, wrapper);
+    public OffsetDateTimeAdapter(OffsetDateTime obj, BeansWrapper wrapper, ZoneStrategy strategy) {
+        super(obj, wrapper, strategy);
     }
-
 
     @Override
     public TemplateModel getForType(String s) throws TemplateModelException {
         if (METHOD_FORMAT.equals(s)) {
-            return new OffsetDateTimeFormatter(getObject());
+            return new OffsetDateTimeFormatter(getObject(), getStrategy());
         }
         throw new TemplateModelException(METHOD_UNKNOWN_MSG + s);
-    }
-
-
-    public class OffsetDateTimeFormatter extends AbstractFormatter<OffsetDateTime> implements TemplateMethodModelEx {
-
-        public OffsetDateTimeFormatter(OffsetDateTime obj) {
-            super(obj);
-        }
-
-
-        @Override
-        public Object exec(List list) throws TemplateModelException {
-            return getObject().format(createDateTimeFormatter(list, 0, DateTimeFormatter.ISO_OFFSET_DATE_TIME));
-        }
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/OffsetDateTimeFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/OffsetDateTimeFormatter.java
@@ -1,0 +1,23 @@
+package no.api.freemarker.java8.time;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
+import no.api.freemarker.java8.zone.ZoneStrategy;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
+
+public class OffsetDateTimeFormatter extends AbstractFormatter<OffsetDateTime> implements TemplateMethodModelEx {
+
+    public OffsetDateTimeFormatter(OffsetDateTime obj, ZoneStrategy strategy) {
+        super(obj, strategy);
+    }
+
+    @Override
+    public Object exec(List list) throws TemplateModelException {
+        return getObject().format(createDateTimeFormatter(list, 0, ISO_OFFSET_DATE_TIME).withZone(getTargetZoneId(list)));
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/time/OffsetDateTimeFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/OffsetDateTimeFormatter.java
@@ -18,6 +18,9 @@ public class OffsetDateTimeFormatter extends AbstractFormatter<OffsetDateTime> i
 
     @Override
     public Object exec(List list) throws TemplateModelException {
-        return getObject().format(createDateTimeFormatter(list, 0, ISO_OFFSET_DATE_TIME).withZone(getTargetZoneId(list)));
+        return getObject().format(
+              createDateTimeFormatter(list, 0, ISO_OFFSET_DATE_TIME)
+                    .withZone(getTargetZoneId(list, getObject().getOffset().normalized()))
+        );
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/OffsetTimeAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/OffsetTimeAdapter.java
@@ -17,49 +17,29 @@
 package no.api.freemarker.java8.time;
 
 import freemarker.ext.beans.BeansWrapper;
-import freemarker.template.AdapterTemplateModel;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateMethodModelEx;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateScalarModel;
+import freemarker.template.*;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 
 import java.time.OffsetTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
 
-import static no.api.freemarker.java8.time.DateTimeTools.*;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_FORMAT;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_UNKNOWN_MSG;
 
 /**
  * OffsetTimeAdapter adds basic format support for {@link OffsetTime} too FreeMarker 2.3.23 and above.
  */
 public class OffsetTimeAdapter extends AbstractAdapter<OffsetTime> implements AdapterTemplateModel,
-        TemplateScalarModel, TemplateHashModel {
+      TemplateScalarModel, TemplateHashModel {
 
-    public OffsetTimeAdapter(OffsetTime obj, BeansWrapper wrapper) {
-        super(obj, wrapper);
+    public OffsetTimeAdapter(OffsetTime obj, BeansWrapper wrapper, ZoneStrategy strategy) {
+        super(obj, wrapper, strategy);
     }
-
 
     @Override
     public TemplateModel getForType(String s) throws TemplateModelException {
         if (METHOD_FORMAT.equals(s)) {
-            return new OffsetTimeFormatter(getObject());
+            return new OffsetTimeFormatter(getObject(), getStrategy());
         }
         throw new TemplateModelException(METHOD_UNKNOWN_MSG + s);
-    }
-
-
-    public class OffsetTimeFormatter extends AbstractFormatter<OffsetTime> implements TemplateMethodModelEx {
-
-        public OffsetTimeFormatter(OffsetTime obj) {
-            super(obj);
-        }
-
-
-        @Override
-        public Object exec(List list) throws TemplateModelException {
-            return getObject().format(createDateTimeFormatter(list, 0, DateTimeFormatter.ISO_OFFSET_TIME));
-        }
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/OffsetTimeFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/OffsetTimeFormatter.java
@@ -1,0 +1,24 @@
+package no.api.freemarker.java8.time;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
+import no.api.freemarker.java8.zone.ZoneStrategy;
+
+import java.time.OffsetTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_TIME;
+import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
+
+public class OffsetTimeFormatter extends AbstractFormatter<OffsetTime> implements TemplateMethodModelEx {
+
+    public OffsetTimeFormatter(OffsetTime obj, ZoneStrategy strategy) {
+        super(obj, strategy);
+    }
+
+    @Override
+    public Object exec(List list) throws TemplateModelException {
+        return getObject().format(createDateTimeFormatter(list, 0, ISO_OFFSET_TIME).withZone(getTargetZoneId(list)));
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/time/OffsetTimeFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/OffsetTimeFormatter.java
@@ -5,7 +5,6 @@ import freemarker.template.TemplateModelException;
 import no.api.freemarker.java8.zone.ZoneStrategy;
 
 import java.time.OffsetTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_TIME;
@@ -19,6 +18,6 @@ public class OffsetTimeFormatter extends AbstractFormatter<OffsetTime> implement
 
     @Override
     public Object exec(List list) throws TemplateModelException {
-        return getObject().format(createDateTimeFormatter(list, 0, ISO_OFFSET_TIME).withZone(getTargetZoneId(list)));
+        return getObject().format(createDateTimeFormatter(list, 0, ISO_OFFSET_TIME));
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/PeriodAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/PeriodAdapter.java
@@ -17,12 +17,8 @@
 package no.api.freemarker.java8.time;
 
 import freemarker.ext.beans.BeansWrapper;
-import freemarker.template.AdapterTemplateModel;
-import freemarker.template.SimpleNumber;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateScalarModel;
+import freemarker.template.*;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 
 import java.time.Period;
 
@@ -33,13 +29,11 @@ import static no.api.freemarker.java8.time.DateTimeTools.*;
  * templates.
  */
 public class PeriodAdapter extends AbstractAdapter<Period> implements AdapterTemplateModel,
-        TemplateScalarModel, TemplateHashModel {
+      TemplateScalarModel, TemplateHashModel {
 
-
-    public PeriodAdapter(Period obj, BeansWrapper wrapper) {
-        super(obj, wrapper);
+    public PeriodAdapter(Period obj, BeansWrapper wrapper, ZoneStrategy strategy) {
+        super(obj, wrapper, strategy);
     }
-
 
     @Override
     public TemplateModel getForType(String s) throws TemplateModelException {

--- a/src/main/java/no/api/freemarker/java8/time/PreparedFormatStyle.java
+++ b/src/main/java/no/api/freemarker/java8/time/PreparedFormatStyle.java
@@ -16,7 +16,6 @@ public enum PreparedFormatStyle implements ExtFormatStyle {
 
     private final DateTimeFormatter formatter;
 
-
     PreparedFormatStyle(final boolean withDate, final boolean withTime, final FormatStyle formatStyle) {
         if (withDate && withTime) {
             this.formatter = DateTimeFormatter.ofLocalizedDateTime(formatStyle);
@@ -26,7 +25,6 @@ public enum PreparedFormatStyle implements ExtFormatStyle {
             this.formatter = DateTimeFormatter.ofLocalizedTime(formatStyle);
         }
     }
-
 
     @Override
     public DateTimeFormatter getFormatter() {

--- a/src/main/java/no/api/freemarker/java8/time/TemporalDialerAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/TemporalDialerAdapter.java
@@ -1,20 +1,19 @@
 package no.api.freemarker.java8.time;
 
 import freemarker.ext.beans.BeansWrapper;
-import freemarker.template.AdapterTemplateModel;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateScalarModel;
+import freemarker.template.*;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalUnit;
 
-public class TemporalDialerAdapter extends AbstractAdapter<Temporal> implements AdapterTemplateModel, TemplateScalarModel, TemplateHashModel {
+public class TemporalDialerAdapter extends AbstractAdapter<Temporal> implements AdapterTemplateModel,
+      TemplateScalarModel, TemplateHashModel {
 
     private final TemplateHashModel delegate;
-    public TemporalDialerAdapter(Temporal obj, BeansWrapper wrapper, TemplateHashModel delegate) {
-        super(obj, wrapper);
+
+    public TemporalDialerAdapter(Temporal obj, BeansWrapper wrapper, TemplateHashModel delegate, ZoneStrategy strategy) {
+        super(obj, wrapper, strategy);
         this.delegate = delegate;
     }
 

--- a/src/main/java/no/api/freemarker/java8/time/TemporalDialerAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/TemporalDialerAdapter.java
@@ -12,7 +12,12 @@ public class TemporalDialerAdapter extends AbstractAdapter<Temporal> implements 
 
     private final TemplateHashModel delegate;
 
-    public TemporalDialerAdapter(Temporal obj, BeansWrapper wrapper, TemplateHashModel delegate, ZoneStrategy strategy) {
+    public TemporalDialerAdapter(
+          Temporal obj,
+          BeansWrapper wrapper,
+          TemplateHashModel delegate,
+          ZoneStrategy strategy
+    ) {
         super(obj, wrapper, strategy);
         this.delegate = delegate;
     }

--- a/src/main/java/no/api/freemarker/java8/time/YearAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/YearAdapter.java
@@ -17,49 +17,29 @@
 package no.api.freemarker.java8.time;
 
 import freemarker.ext.beans.BeansWrapper;
-import freemarker.template.AdapterTemplateModel;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateMethodModelEx;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateScalarModel;
+import freemarker.template.*;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 
 import java.time.Year;
-import java.util.List;
 
-import static no.api.freemarker.java8.time.DateTimeTools.*;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_FORMAT;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_UNKNOWN_MSG;
 
 /**
  * YearAdapter adds basic format support for {@link Year} too FreeMarker 2.3.23 and above.
  */
 public class YearAdapter extends AbstractAdapter<Year> implements AdapterTemplateModel,
-        TemplateScalarModel, TemplateHashModel {
+      TemplateScalarModel, TemplateHashModel {
 
-
-    public YearAdapter(Year obj, BeansWrapper wrapper) {
-        super(obj, wrapper);
+    public YearAdapter(Year obj, BeansWrapper wrapper, ZoneStrategy strategy) {
+        super(obj, wrapper, strategy);
     }
-
 
     @Override
     public TemplateModel getForType(String s) throws TemplateModelException {
         if (METHOD_FORMAT.equals(s)) {
-            return new YearFormatter(getObject());
+            return new YearFormatter(getObject(), getStrategy());
         }
         throw new TemplateModelException(METHOD_UNKNOWN_MSG + s);
-    }
-
-
-    public class YearFormatter extends AbstractFormatter<Year> implements TemplateMethodModelEx {
-
-        public YearFormatter(Year obj) {
-            super(obj);
-        }
-
-
-        @Override
-        public Object exec(List list) throws TemplateModelException {
-            return getObject().format(createDateTimeFormatter(list, 0, "yyyy"));
-        }
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/YearFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/YearFormatter.java
@@ -1,0 +1,21 @@
+package no.api.freemarker.java8.time;
+
+import freemarker.template.TemplateMethodModelEx;
+import no.api.freemarker.java8.zone.ZoneStrategy;
+
+import java.time.Year;
+import java.util.List;
+
+import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
+
+public class YearFormatter extends AbstractFormatter<Year> implements TemplateMethodModelEx {
+
+    public YearFormatter(Year obj, ZoneStrategy strategy) {
+        super(obj, strategy);
+    }
+
+    @Override
+    public Object exec(List list) {
+        return getObject().format(createDateTimeFormatter(list, 0, "yyyy"));
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/time/YearMonthAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/YearMonthAdapter.java
@@ -17,48 +17,30 @@
 package no.api.freemarker.java8.time;
 
 import freemarker.ext.beans.BeansWrapper;
-import freemarker.template.AdapterTemplateModel;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateMethodModelEx;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateScalarModel;
+import freemarker.template.*;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 
 import java.time.YearMonth;
-import java.util.List;
 
-import static no.api.freemarker.java8.time.DateTimeTools.*;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_FORMAT;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_UNKNOWN_MSG;
 
 /**
  * YearMonthAdapter adds basic format support for {@link YearMonth} too FreeMarker 2.3.23 and above.
  */
 public class YearMonthAdapter extends AbstractAdapter<YearMonth> implements AdapterTemplateModel,
-        TemplateScalarModel, TemplateHashModel {
+      TemplateScalarModel, TemplateHashModel {
 
-    public YearMonthAdapter(YearMonth obj, BeansWrapper wrapper) {
-        super(obj, wrapper);
+    public YearMonthAdapter(YearMonth obj, BeansWrapper wrapper, ZoneStrategy strategy) {
+        super(obj, wrapper, strategy);
     }
-
 
     @Override
     public TemplateModel getForType(String s) throws TemplateModelException {
         if (METHOD_FORMAT.equals(s)) {
-            return new YearMonthFormatter(getObject());
+            return new YearMonthFormatter(getObject(), getStrategy());
         }
         throw new TemplateModelException(METHOD_UNKNOWN_MSG + s);
     }
 
-
-    public class YearMonthFormatter extends AbstractFormatter<YearMonth> implements TemplateMethodModelEx {
-
-        public YearMonthFormatter(YearMonth obj) {
-            super(obj);
-        }
-
-
-        @Override
-        public Object exec(List list) throws TemplateModelException {
-            return getObject().format(createDateTimeFormatter(list, 0, "yyyy-MM"));
-        }
-    }
 }

--- a/src/main/java/no/api/freemarker/java8/time/YearMonthFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/YearMonthFormatter.java
@@ -1,0 +1,21 @@
+package no.api.freemarker.java8.time;
+
+import freemarker.template.TemplateMethodModelEx;
+import no.api.freemarker.java8.zone.ZoneStrategy;
+
+import java.time.YearMonth;
+import java.util.List;
+
+import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
+
+public class YearMonthFormatter extends AbstractFormatter<YearMonth> implements TemplateMethodModelEx {
+
+    public YearMonthFormatter(YearMonth obj, ZoneStrategy strategy) {
+        super(obj, strategy);
+    }
+
+    @Override
+    public Object exec(List list) {
+        return getObject().format(createDateTimeFormatter(list, 0, "yyyy-MM"));
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/time/ZoneIdAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/ZoneIdAdapter.java
@@ -18,35 +18,29 @@ package no.api.freemarker.java8.time;
 
 import freemarker.core.Environment;
 import freemarker.ext.beans.BeansWrapper;
-import freemarker.template.AdapterTemplateModel;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateMethodModelEx;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateScalarModel;
+import freemarker.template.*;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 
 import java.time.ZoneId;
 import java.time.format.TextStyle;
-import java.util.List;
 
-import static no.api.freemarker.java8.time.DateTimeTools.*;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_FORMAT;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_UNKNOWN_MSG;
 
 /**
  * ZoneIdAdapter adds basic format support for {@link ZoneId} too FreeMarker 2.3.23 and above.
  */
 public class ZoneIdAdapter extends AbstractAdapter<ZoneId>
-        implements AdapterTemplateModel, TemplateScalarModel, TemplateHashModel {
+      implements AdapterTemplateModel, TemplateScalarModel, TemplateHashModel {
 
-    public ZoneIdAdapter(ZoneId obj, BeansWrapper wrapper) {
-        super(obj, wrapper);
+    public ZoneIdAdapter(ZoneId obj, BeansWrapper wrapper, ZoneStrategy strategy) {
+        super(obj, wrapper, strategy);
     }
-
 
     @Override
-    public String getAsString() throws TemplateModelException {
+    public String getAsString() {
         return getObject().getDisplayName(TextStyle.FULL, Environment.getCurrentEnvironment().getLocale());
     }
-
 
     @Override
     public TemplateModel getForType(String s) throws TemplateModelException {
@@ -54,20 +48,5 @@ public class ZoneIdAdapter extends AbstractAdapter<ZoneId>
             return new ZoneIdFormatter(getObject());
         }
         throw new TemplateModelException(METHOD_UNKNOWN_MSG + s);
-    }
-
-
-    public class ZoneIdFormatter extends AbstractTextStyleLocaleFormatter<ZoneId> implements TemplateMethodModelEx {
-
-        public ZoneIdFormatter(ZoneId obj) {
-            super(obj);
-        }
-
-
-        @Override
-        public Object exec(List list) throws TemplateModelException {
-            return getObject().getDisplayName(findTextStyle(list), findLocale(list));
-        }
-
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/ZoneIdFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/ZoneIdFormatter.java
@@ -1,0 +1,18 @@
+package no.api.freemarker.java8.time;
+
+import freemarker.template.TemplateMethodModelEx;
+
+import java.time.ZoneId;
+import java.util.List;
+
+public class ZoneIdFormatter extends AbstractTextStyleLocaleFormatter<ZoneId> implements TemplateMethodModelEx {
+
+    public ZoneIdFormatter(ZoneId obj) {
+        super(obj);
+    }
+
+    @Override
+    public Object exec(List list) {
+        return getObject().getDisplayName(findTextStyle(list), findLocale(list));
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/time/ZoneOffsetAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/ZoneOffsetAdapter.java
@@ -17,28 +17,23 @@
 package no.api.freemarker.java8.time;
 
 import freemarker.ext.beans.BeansWrapper;
-import freemarker.template.AdapterTemplateModel;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateMethodModelEx;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateScalarModel;
+import freemarker.template.*;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 
 import java.time.ZoneOffset;
-import java.util.List;
 
-import static no.api.freemarker.java8.time.DateTimeTools.*;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_FORMAT;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_UNKNOWN_MSG;
 
 /**
  * ZoneOffsetAdapter adds basic format support for {@link ZoneOffset} too FreeMarker 2.3.23 and above.
  */
 public class ZoneOffsetAdapter extends AbstractAdapter<ZoneOffset> implements AdapterTemplateModel,
-        TemplateScalarModel, TemplateHashModel {
+      TemplateScalarModel, TemplateHashModel {
 
-    public ZoneOffsetAdapter(ZoneOffset obj, BeansWrapper wrapper) {
-        super(obj, wrapper);
+    public ZoneOffsetAdapter(ZoneOffset obj, BeansWrapper wrapper, ZoneStrategy strategy) {
+        super(obj, wrapper, strategy);
     }
-
 
     @Override
     public TemplateModel getForType(String s) throws TemplateModelException {
@@ -47,20 +42,4 @@ public class ZoneOffsetAdapter extends AbstractAdapter<ZoneOffset> implements Ad
         }
         throw new TemplateModelException(METHOD_UNKNOWN_MSG + s);
     }
-
-
-    public class ZoneOffsetFormatter extends AbstractTextStyleLocaleFormatter<ZoneOffset>
-            implements TemplateMethodModelEx {
-
-        public ZoneOffsetFormatter(ZoneOffset obj) {
-            super(obj);
-        }
-
-
-        @Override
-        public Object exec(List list) throws TemplateModelException {
-            return getObject().getDisplayName(findTextStyle(list), findLocale(list));
-        }
-    }
-
 }

--- a/src/main/java/no/api/freemarker/java8/time/ZoneOffsetFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/ZoneOffsetFormatter.java
@@ -1,0 +1,19 @@
+package no.api.freemarker.java8.time;
+
+import freemarker.template.TemplateMethodModelEx;
+
+import java.time.ZoneOffset;
+import java.util.List;
+
+public class ZoneOffsetFormatter extends AbstractTextStyleLocaleFormatter<ZoneOffset>
+      implements TemplateMethodModelEx {
+
+    public ZoneOffsetFormatter(ZoneOffset obj) {
+        super(obj);
+    }
+
+    @Override
+    public Object exec(List list) {
+        return getObject().getDisplayName(findTextStyle(list), findLocale(list));
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/time/ZonedDateTimeAdapter.java
+++ b/src/main/java/no/api/freemarker/java8/time/ZonedDateTimeAdapter.java
@@ -17,74 +17,28 @@
 package no.api.freemarker.java8.time;
 
 import freemarker.ext.beans.BeansWrapper;
-import freemarker.template.AdapterTemplateModel;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateMethodModelEx;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateScalarModel;
-import no.api.freemarker.java8.zone.ZonedDateTimeStrategy;
+import freemarker.template.*;
+import no.api.freemarker.java8.zone.ZoneStrategy;
 
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
 
-import static no.api.freemarker.java8.time.DateTimeTools.*;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_FORMAT;
+import static no.api.freemarker.java8.time.DateTimeTools.METHOD_UNKNOWN_MSG;
 
 /**
  * ZonedDateTimeAdapter adds basic format support for {@link ZonedDateTime} too FreeMarker 2.3.23 and above.
  */
 public class ZonedDateTimeAdapter extends AbstractAdapter<ZonedDateTime> implements AdapterTemplateModel,
-        TemplateScalarModel, TemplateHashModel {
+      TemplateScalarModel, TemplateHashModel {
 
-    private final ZonedDateTimeStrategy strategy;
-
-
-    public ZonedDateTimeAdapter(ZonedDateTime obj, BeansWrapper wrapper, ZonedDateTimeStrategy strategy) {
-        super(obj, wrapper);
-        this.strategy = strategy;
+    public ZonedDateTimeAdapter(ZonedDateTime obj, BeansWrapper wrapper, ZoneStrategy strategy) {
+        super(obj, wrapper, strategy);
     }
-
 
     public TemplateModel getForType(String s) throws TemplateModelException {
         if (METHOD_FORMAT.equals(s)) {
-            return new ZonedDateTimeFormatter(getObject());
+            return new ZonedDateTimeFormatter(getObject(), getStrategy());
         }
         throw new TemplateModelException(METHOD_UNKNOWN_MSG + s);
     }
-
-
-    public class ZonedDateTimeFormatter extends AbstractFormatter<ZonedDateTime> implements TemplateMethodModelEx {
-
-        public ZonedDateTimeFormatter(ZonedDateTime obj) {
-            super(obj);
-        }
-
-
-        @Override
-        public Object exec(final List list) throws TemplateModelException {
-            final ZoneId targetZoneId = getTargetZoneId(list);
-            if (isDifferentTimeZoneRequested(targetZoneId)) {
-                return getObject().withZoneSameInstant(targetZoneId).format(DateTimeTools
-                        .createDateTimeFormatter(list, 0, DateTimeFormatter.ISO_ZONED_DATE_TIME));
-            } else {
-                return getObject()
-                        .format(DateTimeTools.createDateTimeFormatter(list, 0, DateTimeFormatter.ISO_ZONED_DATE_TIME));
-            }
-        }
-
-
-        private ZoneId getTargetZoneId(final List argumentList) throws TemplateModelException {
-            return zoneIdLookup(argumentList, 1).orElse(strategy.getZoneId(getObject().getZone()));
-        }
-
-
-        private boolean isDifferentTimeZoneRequested(ZoneId zoneId) {
-            return !getObject().getZone().equals(zoneId);
-        }
-
-
-    }
-
 }

--- a/src/main/java/no/api/freemarker/java8/time/ZonedDateTimeFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/ZonedDateTimeFormatter.java
@@ -9,6 +9,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 
 import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
+import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
 
 public class ZonedDateTimeFormatter extends AbstractFormatter<ZonedDateTime> implements TemplateMethodModelEx {
 
@@ -18,13 +19,14 @@ public class ZonedDateTimeFormatter extends AbstractFormatter<ZonedDateTime> imp
 
     @Override
     public Object exec(final List list) throws TemplateModelException {
-        final ZoneId targetZoneId = getTargetZoneId(list);
+
+        final ZoneId targetZoneId = getTargetZoneId(list, getObject().getZone());
+
         if (isDifferentTimeZoneRequested(targetZoneId)) {
-            return getObject().withZoneSameInstant(targetZoneId).format(DateTimeTools
-                  .createDateTimeFormatter(list, 0, ISO_ZONED_DATE_TIME));
+            return getObject().withZoneSameInstant(targetZoneId).format(createDateTimeFormatter(list, 0, ISO_ZONED_DATE_TIME));
         } else {
             return getObject()
-                  .format(DateTimeTools.createDateTimeFormatter(list, 0, ISO_ZONED_DATE_TIME));
+                  .format(createDateTimeFormatter(list, 0, ISO_ZONED_DATE_TIME));
         }
     }
 

--- a/src/main/java/no/api/freemarker/java8/time/ZonedDateTimeFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/ZonedDateTimeFormatter.java
@@ -1,0 +1,34 @@
+package no.api.freemarker.java8.time;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
+import no.api.freemarker.java8.zone.ZoneStrategy;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
+
+public class ZonedDateTimeFormatter extends AbstractFormatter<ZonedDateTime> implements TemplateMethodModelEx {
+
+    public ZonedDateTimeFormatter(ZonedDateTime obj, ZoneStrategy strategy) {
+        super(obj, strategy);
+    }
+
+    @Override
+    public Object exec(final List list) throws TemplateModelException {
+        final ZoneId targetZoneId = getTargetZoneId(list);
+        if (isDifferentTimeZoneRequested(targetZoneId)) {
+            return getObject().withZoneSameInstant(targetZoneId).format(DateTimeTools
+                  .createDateTimeFormatter(list, 0, ISO_ZONED_DATE_TIME));
+        } else {
+            return getObject()
+                  .format(DateTimeTools.createDateTimeFormatter(list, 0, ISO_ZONED_DATE_TIME));
+        }
+    }
+
+    private boolean isDifferentTimeZoneRequested(ZoneId zoneId) {
+        return !getObject().getZone().equals(zoneId);
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/zone/EnvironmentZoneStrategy.java
+++ b/src/main/java/no/api/freemarker/java8/zone/EnvironmentZoneStrategy.java
@@ -1,0 +1,31 @@
+package no.api.freemarker.java8.zone;
+
+import freemarker.core.Environment;
+
+import java.time.ZoneId;
+import java.util.TimeZone;
+
+/**
+ * {@link ZoneStrategy} that always will transform the input {@link ZoneId} to the {@link ZoneId} provided by
+ * Environment#getCurrentEnvironment().getTimeZone().getTimeZone().<br>
+ */
+public class EnvironmentZoneStrategy implements ZoneStrategy {
+
+    @Override
+    public ZoneId getZoneId(ZoneId input) {
+        return getZoneId();
+    }
+
+    @Override
+    public ZoneId getZoneId() {
+        Environment env = Environment.getCurrentEnvironment();
+        if (env == null) {
+            throw new IllegalStateException(getClass().getName() + " called outside of a template processing thread");
+        }
+        final TimeZone timeZone = env.getTimeZone();
+        if (timeZone == null) {
+            throw new NullPointerException("Current Environment has no TimeZone set!");
+        }
+        return timeZone.toZoneId();
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/zone/EnvironmentZonedDateTimeStrategy.java
+++ b/src/main/java/no/api/freemarker/java8/zone/EnvironmentZonedDateTimeStrategy.java
@@ -1,26 +1,8 @@
 package no.api.freemarker.java8.zone;
 
-import freemarker.core.Environment;
-
-import java.time.ZoneId;
-import java.util.TimeZone;
-
 /**
- * ZonedDateTimeStrategy that always will transform the input {@link ZoneId} to the {@link ZoneId} provided by
- * Environment#getCurrentEnvironment().getTimeZone().getTimeZone().<br>
+ * @deprecated Use {@link EnvironmentZoneStrategy} instead.
  */
-public class EnvironmentZonedDateTimeStrategy implements ZonedDateTimeStrategy {
-
-    @Override
-    public ZoneId getZoneId(ZoneId input) {
-        Environment env = Environment.getCurrentEnvironment();
-        if (env == null) {
-            throw new IllegalStateException(getClass().getName() + " called outside of a template processing thread");
-        }
-        final TimeZone timeZone = env.getTimeZone();
-        if (timeZone == null) {
-            throw new NullPointerException("Current Environment has no TimeZone set!");
-        }
-        return timeZone.toZoneId();
-    }
+@Deprecated
+public class EnvironmentZonedDateTimeStrategy extends EnvironmentZoneStrategy {
 }

--- a/src/main/java/no/api/freemarker/java8/zone/KeepingZoneStrategy.java
+++ b/src/main/java/no/api/freemarker/java8/zone/KeepingZoneStrategy.java
@@ -1,0 +1,21 @@
+package no.api.freemarker.java8.zone;
+
+import java.time.ZoneId;
+
+/**
+ * {@link ZoneStrategy} that will never transform the {@link ZoneId} returning always the {@code input}.
+ */
+public class KeepingZoneStrategy implements ZoneStrategy {
+
+    private final SystemZoneStrategy system = new SystemZoneStrategy();
+
+    @Override
+    public ZoneId getZoneId(ZoneId input) {
+        return input;
+    }
+
+    @Override
+    public ZoneId getZoneId() {
+        return system.getZoneId();
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/zone/KeepingZonedDateTimeStrategy.java
+++ b/src/main/java/no/api/freemarker/java8/zone/KeepingZonedDateTimeStrategy.java
@@ -1,14 +1,8 @@
 package no.api.freemarker.java8.zone;
 
-import java.time.ZoneId;
-
 /**
- * {@link ZonedDateTimeStrategy} that will never transform the {@link ZoneId} returning always the {@code input}.
+ * @deprecated Use {@link KeepingZoneStrategy} instead.
  */
-public class KeepingZonedDateTimeStrategy implements ZonedDateTimeStrategy {
-
-    @Override
-    public ZoneId getZoneId(ZoneId input) {
-        return input;
-    }
+@Deprecated
+public class KeepingZonedDateTimeStrategy extends KeepingZoneStrategy {
 }

--- a/src/main/java/no/api/freemarker/java8/zone/StaticZoneStrategy.java
+++ b/src/main/java/no/api/freemarker/java8/zone/StaticZoneStrategy.java
@@ -1,0 +1,33 @@
+package no.api.freemarker.java8.zone;
+
+import java.time.ZoneId;
+
+/**
+ * {@link ZoneStrategy} that always will transform the input {@link ZoneId} to the initial set {@link ZoneId}.
+ */
+public class StaticZoneStrategy implements ZoneStrategy {
+
+    private final ZoneId zoneId;
+
+    /**
+     * Creates a new {@link StaticZoneStrategy} instance, that will always return the given [{@code zone}.
+     *
+     * @param zoneId The {@link ZoneId} that should be returned by {@link #getZoneId(ZoneId)}.
+     */
+    public StaticZoneStrategy(ZoneId zoneId) {
+        if (zoneId == null) {
+            throw new NullPointerException("provided zoneId is null");
+        }
+        this.zoneId = zoneId;
+    }
+
+    @Override
+    public ZoneId getZoneId(ZoneId input) {
+        return getZoneId();
+    }
+
+    @Override
+    public ZoneId getZoneId() {
+        return this.zoneId;
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/zone/StaticZonedDateTimeStrategy.java
+++ b/src/main/java/no/api/freemarker/java8/zone/StaticZonedDateTimeStrategy.java
@@ -3,28 +3,12 @@ package no.api.freemarker.java8.zone;
 import java.time.ZoneId;
 
 /**
- * ZonedDateTimeStrategy that always will transform the input {@link ZoneId} to the initial set {@link ZoneId}.
+ * @deprecated Use {@link StaticZoneStrategy} instead.
  */
-public class StaticZonedDateTimeStrategy implements ZonedDateTimeStrategy {
+@Deprecated
+public class StaticZonedDateTimeStrategy extends StaticZoneStrategy {
 
-    private final ZoneId zoneId;
-
-
-    /**
-     * Creates a new {@link StaticZonedDateTimeStrategy} instance, that will always return the given [{@code zone}.
-     *
-     * @param zoneId The {@link ZoneId} that should be returned by {@link #getZoneId(ZoneId)}.
-     */
     public StaticZonedDateTimeStrategy(ZoneId zoneId) {
-        if (zoneId == null) {
-            throw new NullPointerException("provided zoneId is null");
-        }
-        this.zoneId = zoneId;
-    }
-
-
-    @Override
-    public ZoneId getZoneId(ZoneId input) {
-        return this.zoneId;
+        super(zoneId);
     }
 }

--- a/src/main/java/no/api/freemarker/java8/zone/SystemZoneStrategy.java
+++ b/src/main/java/no/api/freemarker/java8/zone/SystemZoneStrategy.java
@@ -1,0 +1,20 @@
+package no.api.freemarker.java8.zone;
+
+import java.time.ZoneId;
+
+/**
+ * {@link ZoneStrategy} that always will transform the input {@link ZoneId} to the {@link ZoneId} provided by
+ * {@link ZoneId#systemDefault()}.
+ */
+public class SystemZoneStrategy implements ZoneStrategy {
+
+    @Override
+    public ZoneId getZoneId(ZoneId input) {
+        return getZoneId();
+    }
+
+    @Override
+    public ZoneId getZoneId() {
+        return ZoneId.systemDefault();
+    }
+}

--- a/src/main/java/no/api/freemarker/java8/zone/SystemZonedDateTimeStrategy.java
+++ b/src/main/java/no/api/freemarker/java8/zone/SystemZonedDateTimeStrategy.java
@@ -1,15 +1,8 @@
 package no.api.freemarker.java8.zone;
 
-import java.time.ZoneId;
-
 /**
- * {@link ZonedDateTimeStrategy} that always will transform the input {@link ZoneId} to the {@link ZoneId} provided by
- * {@link ZoneId#systemDefault()}.<br>
+ * @deprecated Use {@link SystemZoneStrategy} instead.
  */
-public class SystemZonedDateTimeStrategy implements ZonedDateTimeStrategy {
-
-    @Override
-    public ZoneId getZoneId(ZoneId input) {
-        return ZoneId.systemDefault();
-    }
+@Deprecated
+public class SystemZonedDateTimeStrategy extends SystemZoneStrategy {
 }

--- a/src/main/java/no/api/freemarker/java8/zone/ZoneStrategy.java
+++ b/src/main/java/no/api/freemarker/java8/zone/ZoneStrategy.java
@@ -1,0 +1,26 @@
+package no.api.freemarker.java8.zone;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+/**
+ * Defines the general strategy used when dealing with zones in different parts of the DateTime API.
+ */
+public interface ZoneStrategy {
+
+    /**
+     * Return the ZoneId to use for formatting a java.time object.
+     *
+     * @param input The current {@link ZoneId} provided by a java.time object or method parameter.
+     * @return The {@link ZoneId} that should be used for formatting the {@link ZonedDateTime} object.
+     */
+    ZoneId getZoneId(ZoneId input);
+
+    /**
+     * Return the ZoneId to use for formatting a java.time object, when no zone information exists on object and are
+     * not given as a parameter.
+     *
+     * @return The {@link ZoneId} that should be used for formatting the object.
+     */
+    ZoneId getZoneId();
+}

--- a/src/main/java/no/api/freemarker/java8/zone/ZonedDateTimeStrategy.java
+++ b/src/main/java/no/api/freemarker/java8/zone/ZonedDateTimeStrategy.java
@@ -1,37 +1,8 @@
 package no.api.freemarker.java8.zone;
 
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-
 /**
- * Can transform a given {@link ZoneId} into another, based on rules set by the implementing classes.
- *
- * <p>Within freemarker-java-8 this is used only within the {@link no.api.freemarker.java8.time.ZonedDateTimeAdapter} to
- * figure out what {@link ZoneId} to use when formatting a {@link ZonedDateTime} into a {@link String}.</p>
- *
- * <h3>Example</h3>
- *
- * <pre>
- *     zoned_date_time_object.format('yyyy-MM-dd Z')
- * </pre>
- *
- * <p>
- * In the about example the {@link ZonedDateTime} object will by default be formatted with the same timezone as found
- * inside the object. This was not the case in earlier versions of the library, where we would use the system timezone.
- * But this might not be the wanted default behaviour for everybody. By introducing this interface it is possible
- * to control what timezone to use as default when formatting a {@link ZonedDateTime} and no timezone is specified in
- * the format method.
- * </p>
+ * @deprecated Use {@link ZoneStrategy} instead.
  */
-public interface ZonedDateTimeStrategy {
-
-    /**
-     * Return the ZoneId to use when formatting a {@link ZonedDateTime}
-     *
-     * @param input The current {@link ZoneId} from a {@link ZonedDateTime} object.
-     * @return The {@link ZoneId} that should be used when formatting the {@link ZonedDateTime} object.
-     */
-    ZoneId getZoneId(ZoneId input);
-
-
+@Deprecated
+public interface ZonedDateTimeStrategy extends ZoneStrategy {
 }

--- a/src/test/java/no/api/freemarker/java8/time/DateTimeStepdefs.java
+++ b/src/test/java/no/api/freemarker/java8/time/DateTimeStepdefs.java
@@ -21,7 +21,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
-import static freemarker.template.Configuration.VERSION_2_3_23;
+import static freemarker.template.Configuration.VERSION_2_3_31;
 
 public class DateTimeStepdefs {
 
@@ -36,8 +36,8 @@ public class DateTimeStepdefs {
     private Java8ObjectWrapper objectWrapper;
 
     public DateTimeStepdefs() {
-        this.configuration = new Configuration(Configuration.VERSION_2_3_23);
-        this.objectWrapper = new Java8ObjectWrapper(VERSION_2_3_23, new KeepingZoneStrategy());
+        this.configuration = new Configuration(VERSION_2_3_31);
+        this.objectWrapper = new Java8ObjectWrapper(VERSION_2_3_31, new KeepingZoneStrategy());
         this.configuration.setObjectWrapper(objectWrapper);
     }
 
@@ -47,7 +47,7 @@ public class DateTimeStepdefs {
     }
 
     private void setStrategy(ZoneStrategy strategy) {
-        setStrategy(VERSION_2_3_23, strategy);
+        setStrategy(VERSION_2_3_31, strategy);
     }
 
     private void setStrategy(Version freemarkerVersion, ZoneStrategy strategy) {

--- a/src/test/java/no/api/freemarker/java8/time/DateTimeStepdefs.java
+++ b/src/test/java/no/api/freemarker/java8/time/DateTimeStepdefs.java
@@ -3,6 +3,7 @@ package no.api.freemarker.java8.time;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
+import freemarker.template.Version;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import no.api.freemarker.java8.Java8ObjectWrapper;
@@ -34,85 +35,80 @@ public class DateTimeStepdefs {
 
     private Java8ObjectWrapper objectWrapper;
 
-
     public DateTimeStepdefs() {
         this.configuration = new Configuration(Configuration.VERSION_2_3_23);
-        this.objectWrapper = new Java8ObjectWrapper(VERSION_2_3_23, new KeepingZonedDateTimeStrategy());
+        this.objectWrapper = new Java8ObjectWrapper(VERSION_2_3_23, new KeepingZoneStrategy());
         this.configuration.setObjectWrapper(objectWrapper);
     }
-
 
     @After
     public void runAfterHooks() {
-        setStrategy(new KeepingZonedDateTimeStrategy());
+        setStrategy(new KeepingZoneStrategy());
     }
 
+    private void setStrategy(ZoneStrategy strategy) {
+        setStrategy(VERSION_2_3_23, strategy);
+    }
 
-    private void setStrategy(ZonedDateTimeStrategy strategy) {
-        this.objectWrapper = new Java8ObjectWrapper(VERSION_2_3_23, strategy);
+    private void setStrategy(Version freemarkerVersion, ZoneStrategy strategy) {
+        this.objectWrapper = new Java8ObjectWrapper(freemarkerVersion, strategy);
         this.configuration.setObjectWrapper(objectWrapper);
     }
-
 
     @Given("^ZonedDateTime object for \"([^\"]*)\"$")
     public void zoneddatetime_object_for_T_Europe_Paris(String arg1) {
         obj = ZonedDateTime.parse(arg1);
     }
 
-
     @Given("^an freemarker environment with locale set to \"([^\"]*)\"$")
     public void an_freemarker_environment_with_locate_set_to(String arg1) {
         configuration.setLocale(Locale.forLanguageTag(arg1));
     }
-
 
     @Given("^timezone set to \"([^\"]*)\"$")
     public void timezone_set_to(String arg1) {
         configuration.setTimeZone(TimeZone.getTimeZone(ZoneId.of(arg1)));
     }
 
-
     @Given("^a template \"([^\"]*)\"$")
     public void a_template_$_zoneid(String template) {
         this.template = template;
     }
-
 
     @Given("^a ZoneId object for '(.*?)'$")
     public void a_ZoneId_object_for_Europe_Oslo(String zone) {
         obj = ZoneId.of(zone);
     }
 
-
     @Given("^timezone strategy set to 'system'$")
     public void timezone_strategy_set_to_system() {
-        setStrategy(new SystemZonedDateTimeStrategy());
+        setStrategy(new SystemZoneStrategy());
     }
-
 
     @Given("^timezone strategy set to 'keeping'$")
     public void timezone_strategy_set_to_keeping() {
-        setStrategy(new KeepingZonedDateTimeStrategy());
+        setStrategy(new KeepingZoneStrategy());
     }
-
 
     @Given("^timezone strategy set to 'environment'$")
     public void timezone_strategy_set_to_environment() {
-        setStrategy(new EnvironmentZonedDateTimeStrategy());
+        setStrategy(new EnvironmentZoneStrategy());
     }
-
 
     @Given("^timezone strategy set to 'static' with timezone \"([^\"]*)\"$")
     public void timezone_strategy_set_to_static_with_timezone(final String arg1) {
-        setStrategy(new StaticZonedDateTimeStrategy(ZoneId.of(arg1)));
+        setStrategy(new StaticZoneStrategy(ZoneId.of(arg1)));
     }
 
+    @Given("^timezone strategy set to 'static' with freemarker version 2_3_31$")
+    public void timezone_strategy_set_to_static_with_version(final String arg1) {
+        setStrategy(Configuration.VERSION_2_3_31, new StaticZoneStrategy(ZoneId.of(arg1)));
+    }
 
     @Given("^system timezone set to \"([^\"]*)\"$")
     public void system_timezone_set_to(final String arg1) {
         TimeZone.setDefault(TimeZone.getTimeZone(arg1));
     }
-
 
     @Then("^expect the template to return \"([^\"]*)\"$")
     public void expect_the_template_to_return(String res) throws Throwable {
@@ -123,7 +119,6 @@ public class DateTimeStepdefs {
         }
     }
 
-
     @Then("^expect the template to return \"([^\"]*)\" or \"([^\"]*)\"$")
     public void expect_the_template_to_return(String res, String res2) throws Throwable {
         try (Writer out = process(res)) {
@@ -132,7 +127,6 @@ public class DateTimeStepdefs {
             }
         }
     }
-
 
     @Then("^expect the template to return the current year$")
     public void expect_the_template_to_return_the_current_year() throws Throwable {
@@ -144,7 +138,6 @@ public class DateTimeStepdefs {
         }
     }
 
-
     @Then("^expect the template to return true$")
     public void expect_the_template_to_true() throws Throwable {
         try (Writer out = process("true")) {
@@ -154,7 +147,6 @@ public class DateTimeStepdefs {
         }
     }
 
-
     @Then("^expect the template to return false$")
     public void expect_the_template_to_false() throws Throwable {
         try (Writer out = process("false")) {
@@ -163,7 +155,6 @@ public class DateTimeStepdefs {
             }
         }
     }
-
 
     private Writer process(String res) throws IOException, TemplateException {
         Map<String, Object> map = new HashMap<>();
@@ -181,102 +172,85 @@ public class DateTimeStepdefs {
         return out;
     }
 
-
     @Given("^YearMonth object for \"([^\"]*)\"$")
     public void yearmonth_object_for(String arg1) {
         obj = YearMonth.parse(arg1);
     }
-
 
     @Given("^Year object for \"([^\"]*)\"$")
     public void year_object_for(String arg1) {
         obj = Year.parse(arg1);
     }
 
-
     @Then("^expect UnsupportedTemporalTypeException$")
     public void expect_UnsupportedTemporalTypeException() {
         obj = Year.now();
     }
-
 
     @Given("^Clock object for \"([^\"]*)\"$")
     public void clock_object_for(String arg1) {
         obj = Clock.fixed(Instant.parse(arg1), configuration.getTimeZone().toZoneId());
     }
 
-
     @Given("^Duration object for \"([^\"]*)\"$")
     public void duration_object_for(String arg1) {
         obj = Duration.parse(arg1);
     }
-
 
     @Given("^Instant object for \"([^\"]*)\"$")
     public void instant_object_for(String arg1) {
         obj = Instant.parse(arg1);
     }
 
-
     @Given("^LocalDate object for \"([^\"]*)\"$")
     public void localdate_object_for(String arg1) {
         obj = LocalDate.parse(arg1);
     }
-
 
     @Given("^LocalDate object2 for \"([^\"]*)\"$")
     public void localdate_object2_for(String arg1) {
         obj2 = LocalDate.parse(arg1);
     }
 
-
     @Given("^LocalDateTime object for \"([^\"]*)\"$")
     public void localdatetime_object_for(String arg1) {
         obj = LocalDateTime.parse(arg1);
     }
-
 
     @Given("^LocalDateTime object2 for \"([^\"]*)\"$")
     public void localdatetime_object2_for(String arg1) {
         obj2 = LocalDateTime.parse(arg1);
     }
 
-
     @Given("^LocalTime object for \"([^\"]*)\"$")
     public void localtime_object_for(String arg1) {
         obj = LocalTime.parse(arg1);
     }
-
 
     @Given("^LocalTime object2 for \"([^\"]*)\"$")
     public void localtime_object2_for(String arg1) {
         obj2 = LocalTime.parse(arg1);
     }
 
-
     @Given("^MonthDay object for \"([^\"]*)\"$")
     public void monthday_object_for(String arg1) {
         obj = MonthDay.parse(arg1);
     }
-
 
     @Given("^OffsetDateTime object for \"([^\"]*)\"$")
     public void offsetdatetime_object_for(String arg1) {
         obj = OffsetDateTime.parse(arg1);
     }
 
-
     @Given("^OffsetTime object for \"([^\"]*)\"$")
     public void offsettime_object_for(String arg1) {
         obj = OffsetTime.parse(arg1);
     }
 
-
     @Given("^Period object for \"([^\"]*)\"$")
     public void period_object_for(String arg1) {
         obj = Period.parse(arg1);
     }
-
 
     @Given("^ZoneOffset object for \"([^\"]*)\"$")
     public void zoneoffset_object_for(Integer arg1) {

--- a/src/test/java/no/api/freemarker/java8/time/TemplateTest.java
+++ b/src/test/java/no/api/freemarker/java8/time/TemplateTest.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 public class TemplateTest {
 
-    public static final Version FMV = Configuration.VERSION_2_3_23;
+    public static final Version FMV = Configuration.VERSION_2_3_31;
 
     @Test
     public void testFull() throws IOException {

--- a/src/test/java/no/api/freemarker/java8/time/TemplateTest.java
+++ b/src/test/java/no/api/freemarker/java8/time/TemplateTest.java
@@ -5,7 +5,7 @@ import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import freemarker.template.Version;
 import no.api.freemarker.java8.Java8ObjectWrapper;
-import no.api.freemarker.java8.zone.KeepingZonedDateTimeStrategy;
+import no.api.freemarker.java8.zone.KeepingZoneStrategy;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -17,24 +17,21 @@ import java.util.Map;
 
 public class TemplateTest {
 
-
     public static final Version FMV = Configuration.VERSION_2_3_23;
-
 
     @Test
     public void testFull() throws IOException {
         // Create FreeMarker configuration
         Configuration cfg = new Configuration(FMV);
         // Override the default ObjectWrapper with the one from freemarker-java-8
-        cfg.setObjectWrapper(new Java8ObjectWrapper(FMV, new KeepingZonedDateTimeStrategy()));
+        cfg.setObjectWrapper(new Java8ObjectWrapper(FMV, new KeepingZoneStrategy()));
         // Set class for template loading. In this case the test class itself
         cfg.setClassForTemplateLoading(this.getClass(), "/templates");
         cfg.setDefaultEncoding("UTF-8");
 
         // Load or full FreeMarker template tester
         Template template = cfg.getTemplate("full.ftl");
-
-
+        
         Map<String, Object> templateData = new HashMap<>();
         templateData.put("clock", Clock.system(ZoneId.of("Europe/Oslo")));
 

--- a/src/test/resources/no/api/freemarker/java8/time/comparison.feature
+++ b/src/test/resources/no/api/freemarker/java8/time/comparison.feature
@@ -149,3 +149,10 @@ Feature: Test the implemented comparison functions (isEqual, isBefore and isAfte
         And LocalTime object for "23:54"
         And LocalTime object2 for "23:45"
         Then expect the template to return false
+
+    Scenario: Test that instant is printed correctly with Freemarker 2_3_31
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('yyyy-MM-dd HH: mm : ss Z', 'Europe/Oslo')}"
+        And Instant object for "2022-06-01T16:17:45Z"
+        Then expect the template to return "2022-06-01 18: 17 : 45 +0200"

--- a/src/test/resources/no/api/freemarker/java8/time/comparison.feature
+++ b/src/test/resources/no/api/freemarker/java8/time/comparison.feature
@@ -150,9 +150,3 @@ Feature: Test the implemented comparison functions (isEqual, isBefore and isAfte
         And LocalTime object2 for "23:45"
         Then expect the template to return false
 
-    Scenario: Test that instant is printed correctly with Freemarker 2_3_31
-        Given an freemarker environment with locale set to "no-NO"
-        And timezone set to "Europe/Oslo"
-        And a template "${obj.format('yyyy-MM-dd HH: mm : ss Z', 'Europe/Oslo')}"
-        And Instant object for "2022-06-01T16:17:45Z"
-        Then expect the template to return "2022-06-01 18: 17 : 45 +0200"

--- a/src/test/resources/no/api/freemarker/java8/time/datetime.feature
+++ b/src/test/resources/no/api/freemarker/java8/time/datetime.feature
@@ -52,6 +52,12 @@ Feature: Test the date time functionality
         And Instant object for "2007-12-03T10:15:30.00Z"
         Then expect the template to return "1196676930000"
 
+    Scenario: Test that instant is printed correctly with Freemarker 2_3_31
+        Given an freemarker environment with locale set to "no-NO"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.format('yyyy-MM-dd HH: mm : ss Z', 'Europe/Oslo')}"
+        And Instant object for "2022-06-01T16:17:45Z"
+        Then expect the template to return "2022-06-01 18: 17 : 45 +0200"
 
     ### LocalDate ###
     Scenario: Test basic LocalDate use in template
@@ -136,6 +142,21 @@ Feature: Test the date time functionality
         And a template "${obj.format('EEEE d MMMM yyyy HH:mm:ss')}"
         And LocalDateTime object for "2007-12-03T10:15:30"
         Then expect the template to return "mandag 3 desember 2007 10:15:30"
+
+    Scenario: Test LocalDateTime use with conversion to ZoneDateTime with configured zone
+        Given an freemarker environment with locale set to "no-No"
+        And timezone strategy set to 'static' with timezone "Europe/Oslo"
+        And timezone set to "Europe/Oslo"
+        And a template "${obj.toZonedDateTime().format('EEEE d MMMM yyyy HH:mm:ss Z')}"
+        And LocalDateTime object for "2007-12-03T10:15:30"
+        Then expect the template to return "mandag 3 desember 2007 10:15:30 +0100"
+
+    Scenario: Test LocalDateTime use with conversion to ZoneDateTime with custom zone
+        Given an freemarker environment with locale set to "no-No"
+        And timezone strategy set to 'static' with timezone "Europe/Oslo"
+        And a template "${obj.toZonedDateTime('Asia/Seoul').format('EEEE d MMMM yyyy HH:mm:ss Z', 'Asia/Seoul')}"
+        And LocalDateTime object for "2007-12-03T10:15:30"
+        Then expect the template to return "mandag 3 desember 2007 18:15:30 +0900"
 
     Scenario: Test basic LocalDateTime use in template with LONG_DATE
         Given an freemarker environment with locale set to "no-No"


### PR DESCRIPTION
One thing led to another, so here we are with a lot of changes (and a major refactoring)

* Upgraded from 2_3_23 to 2_3_31 in test and code.
* format now properly implemented for `Instant` and `Clock`
* Introduced a `toZoneDateTime` for `LocalDateTime` objects. 
* Added zone support for `OffsetDateTime`
* Deprecated ZonedDateTimeStrategy-classes/interface, and introduced new ZoneStrategy-variants. It is the same, but renamed as Zones no longer are supported for only ZoneDateTime.
* Big overhaul of the documentation.