### PR TITLE
30 add support for default format per time class

### DIFF
--- a/src/main/java/no/api/freemarker/java8/time/ClockFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/ClockFormatter.java
@@ -7,7 +7,6 @@ import no.api.freemarker.java8.zone.ZoneStrategy;
 import java.time.Clock;
 import java.util.List;
 
-import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
 
 public class ClockFormatter extends AbstractFormatter<Clock> implements TemplateMethodModelEx {
@@ -18,7 +17,7 @@ public class ClockFormatter extends AbstractFormatter<Clock> implements Template
 
     @Override
     public Object exec(List list) throws TemplateModelException {
-        return createDateTimeFormatter(list, 0, ISO_LOCAL_DATE_TIME)
+        return createDateTimeFormatter(list, 0, DefaultFormatters.getClockFormatter())
               .withZone(getTargetZoneId(list, null))
               .format(getObject().instant());
     }

--- a/src/main/java/no/api/freemarker/java8/time/DefaultFormatters.java
+++ b/src/main/java/no/api/freemarker/java8/time/DefaultFormatters.java
@@ -1,0 +1,119 @@
+package no.api.freemarker.java8.time;
+
+import java.time.format.DateTimeFormatter;
+
+import static java.time.format.DateTimeFormatter.*;
+
+public class DefaultFormatters {
+
+    private static DateTimeFormatter clockFormatter = ISO_LOCAL_DATE_TIME;
+
+    private static DateTimeFormatter instantFormatter = ISO_LOCAL_DATE_TIME;
+
+    private static DateTimeFormatter localDateFormatter = ISO_LOCAL_DATE;
+
+    private static DateTimeFormatter localDateTimeFormatter = ISO_LOCAL_DATE_TIME;
+
+    private static DateTimeFormatter localTimeFormatter = ISO_LOCAL_TIME;
+
+    private static DateTimeFormatter monthDayFormatter = DateTimeFormatter.ofPattern("MM:dd");
+
+    private static DateTimeFormatter offsetDateTimeFormatter = ISO_OFFSET_DATE_TIME;
+
+    private static DateTimeFormatter offsetTimeFormatter = ISO_OFFSET_TIME;
+
+    private static DateTimeFormatter yearFormatter = DateTimeFormatter.ofPattern("yyyy");
+
+    private static DateTimeFormatter yearMonthFormatter = DateTimeFormatter.ofPattern("yyyy-MM");
+
+    private static DateTimeFormatter zonedDateTimeFormatter = ISO_ZONED_DATE_TIME;
+
+    public static DateTimeFormatter getClockFormatter() {
+        return clockFormatter;
+    }
+
+    public static void setClockFormatter(DateTimeFormatter clockFormatter) {
+        DefaultFormatters.clockFormatter = clockFormatter;
+    }
+
+    public static DateTimeFormatter getInstantFormatter() {
+        return instantFormatter;
+    }
+
+    public static void setInstantFormatter(DateTimeFormatter instantFormatter) {
+        DefaultFormatters.instantFormatter = instantFormatter;
+    }
+
+    public static DateTimeFormatter getLocalDateFormatter() {
+        return localDateFormatter;
+    }
+
+    public static void setLocalDateFormatter(DateTimeFormatter localDateFormatter) {
+        DefaultFormatters.localDateFormatter = localDateFormatter;
+    }
+
+    public static DateTimeFormatter getLocalDateTimeFormatter() {
+        return localDateTimeFormatter;
+    }
+
+    public static void setLocalDateTimeFormatter(DateTimeFormatter localDateTimeFormatter) {
+        DefaultFormatters.localDateTimeFormatter = localDateTimeFormatter;
+    }
+
+    public static DateTimeFormatter getLocalTimeFormatter() {
+        return localTimeFormatter;
+    }
+
+    public static void setLocalTimeFormatter(DateTimeFormatter localTimeFormatter) {
+        DefaultFormatters.localTimeFormatter = localTimeFormatter;
+    }
+
+    public static DateTimeFormatter getMonthDayFormatter() {
+        return monthDayFormatter;
+    }
+
+    public static void setMonthDayFormatter(DateTimeFormatter monthDayFormatter) {
+        DefaultFormatters.monthDayFormatter = monthDayFormatter;
+    }
+
+    public static DateTimeFormatter getOffsetDateTimeFormatter() {
+        return offsetDateTimeFormatter;
+    }
+
+    public static void setOffsetDateTimeFormatter(DateTimeFormatter offsetDateTimeFormatter) {
+        DefaultFormatters.offsetDateTimeFormatter = offsetDateTimeFormatter;
+    }
+
+    public static DateTimeFormatter getOffsetTimeFormatter() {
+        return offsetTimeFormatter;
+    }
+
+    public static void setOffsetTimeFormatter(DateTimeFormatter offsetTimeFormatter) {
+        DefaultFormatters.offsetTimeFormatter = offsetTimeFormatter;
+    }
+
+    public static DateTimeFormatter getYearFormatter() {
+        return yearFormatter;
+    }
+
+    public static void setYearFormatter(DateTimeFormatter yearFormatter) {
+        DefaultFormatters.yearFormatter = yearFormatter;
+    }
+
+    public static DateTimeFormatter getYearMonthFormatter() {
+        return yearMonthFormatter;
+    }
+
+    public static void setYearMonthFormatter(DateTimeFormatter yearMonthFormatter) {
+        DefaultFormatters.yearMonthFormatter = yearMonthFormatter;
+    }
+
+    public static DateTimeFormatter getZonedDateTimeFormatter() {
+        return zonedDateTimeFormatter;
+    }
+
+    public static void setZonedDateTimeFormatter(DateTimeFormatter zonedDateTimeFormatter) {
+        DefaultFormatters.zonedDateTimeFormatter = zonedDateTimeFormatter;
+    }
+
+}

--- a/src/main/java/no/api/freemarker/java8/time/InstantFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/InstantFormatter.java
@@ -7,7 +7,6 @@ import no.api.freemarker.java8.zone.ZoneStrategy;
 import java.time.Instant;
 import java.util.List;
 
-import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
 
 public class InstantFormatter extends AbstractFormatter<Instant> implements TemplateMethodModelEx {
@@ -18,7 +17,7 @@ public class InstantFormatter extends AbstractFormatter<Instant> implements Temp
 
     @Override
     public Object exec(List list) throws TemplateModelException {
-        return createDateTimeFormatter(list, 0, ISO_LOCAL_DATE_TIME)
+        return createDateTimeFormatter(list, 0, DefaultFormatters.getInstantFormatter())
               .withZone(getTargetZoneId(list, null))
               .format(getObject());
     }

--- a/src/main/java/no/api/freemarker/java8/time/LocalDateFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalDateFormatter.java
@@ -7,7 +7,6 @@ import no.api.freemarker.java8.zone.ZoneStrategy;
 import java.time.LocalDate;
 import java.util.List;
 
-import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
 
 public class LocalDateFormatter extends AbstractFormatter<LocalDate> implements TemplateMethodModelEx {
@@ -19,6 +18,6 @@ public class LocalDateFormatter extends AbstractFormatter<LocalDate> implements 
     @Override
     public Object exec(List list) throws TemplateModelException {
         return getObject()
-              .format(createDateTimeFormatter(list, 0, ISO_LOCAL_DATE));
+              .format(createDateTimeFormatter(list, 0, DefaultFormatters.getLocalDateFormatter()));
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/LocalDateTimeFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalDateTimeFormatter.java
@@ -7,7 +7,6 @@ import no.api.freemarker.java8.zone.ZoneStrategy;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
 
 public class LocalDateTimeFormatter extends AbstractFormatter<LocalDateTime> implements TemplateMethodModelEx {
@@ -18,6 +17,8 @@ public class LocalDateTimeFormatter extends AbstractFormatter<LocalDateTime> imp
 
     @Override
     public Object exec(List list) throws TemplateModelException {
-        return getObject().format(createDateTimeFormatter(list, 0, ISO_LOCAL_DATE_TIME).withZone(getTargetZoneId(list, null)));
+        return getObject()
+              .format(createDateTimeFormatter(list, 0, DefaultFormatters.getLocalDateTimeFormatter())
+                    .withZone(getTargetZoneId(list, null)));
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/LocalTimeFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/LocalTimeFormatter.java
@@ -7,7 +7,6 @@ import no.api.freemarker.java8.zone.ZoneStrategy;
 import java.time.LocalTime;
 import java.util.List;
 
-import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
 
 public class LocalTimeFormatter extends AbstractFormatter<LocalTime> implements TemplateMethodModelEx {
@@ -18,6 +17,6 @@ public class LocalTimeFormatter extends AbstractFormatter<LocalTime> implements 
 
     @Override
     public Object exec(List list) throws TemplateModelException {
-        return getObject().format(createDateTimeFormatter(list, 0, ISO_LOCAL_TIME));
+        return getObject().format(createDateTimeFormatter(list, 0, DefaultFormatters.getLocalTimeFormatter()));
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/MonthDayFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/MonthDayFormatter.java
@@ -17,6 +17,6 @@ public class MonthDayFormatter extends AbstractFormatter<MonthDay> implements Te
 
     @Override
     public Object exec(List list) throws TemplateModelException {
-        return getObject().format(createDateTimeFormatter(list, 0, "MM:dd"));
+        return getObject().format(createDateTimeFormatter(list, 0, DefaultFormatters.getMonthDayFormatter()));
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/OffsetDateTimeFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/OffsetDateTimeFormatter.java
@@ -7,7 +7,6 @@ import no.api.freemarker.java8.zone.ZoneStrategy;
 import java.time.OffsetDateTime;
 import java.util.List;
 
-import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
 
 public class OffsetDateTimeFormatter extends AbstractFormatter<OffsetDateTime> implements TemplateMethodModelEx {
@@ -19,7 +18,7 @@ public class OffsetDateTimeFormatter extends AbstractFormatter<OffsetDateTime> i
     @Override
     public Object exec(List list) throws TemplateModelException {
         return getObject().format(
-              createDateTimeFormatter(list, 0, ISO_OFFSET_DATE_TIME)
+              createDateTimeFormatter(list, 0, DefaultFormatters.getOffsetDateTimeFormatter())
                     .withZone(getTargetZoneId(list, getObject().getOffset().normalized()))
         );
     }

--- a/src/main/java/no/api/freemarker/java8/time/OffsetTimeFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/OffsetTimeFormatter.java
@@ -7,7 +7,6 @@ import no.api.freemarker.java8.zone.ZoneStrategy;
 import java.time.OffsetTime;
 import java.util.List;
 
-import static java.time.format.DateTimeFormatter.ISO_OFFSET_TIME;
 import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
 
 public class OffsetTimeFormatter extends AbstractFormatter<OffsetTime> implements TemplateMethodModelEx {
@@ -18,6 +17,6 @@ public class OffsetTimeFormatter extends AbstractFormatter<OffsetTime> implement
 
     @Override
     public Object exec(List list) throws TemplateModelException {
-        return getObject().format(createDateTimeFormatter(list, 0, ISO_OFFSET_TIME));
+        return getObject().format(createDateTimeFormatter(list, 0, DefaultFormatters.getOffsetTimeFormatter()));
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/YearFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/YearFormatter.java
@@ -16,6 +16,6 @@ public class YearFormatter extends AbstractFormatter<Year> implements TemplateMe
 
     @Override
     public Object exec(List list) {
-        return getObject().format(createDateTimeFormatter(list, 0, "yyyy"));
+        return getObject().format(createDateTimeFormatter(list, 0, DefaultFormatters.getYearFormatter()));
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/YearMonthFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/YearMonthFormatter.java
@@ -16,6 +16,6 @@ public class YearMonthFormatter extends AbstractFormatter<YearMonth> implements 
 
     @Override
     public Object exec(List list) {
-        return getObject().format(createDateTimeFormatter(list, 0, "yyyy-MM"));
+        return getObject().format(createDateTimeFormatter(list, 0, DefaultFormatters.getYearMonthFormatter()));
     }
 }

--- a/src/main/java/no/api/freemarker/java8/time/ZonedDateTimeFormatter.java
+++ b/src/main/java/no/api/freemarker/java8/time/ZonedDateTimeFormatter.java
@@ -8,7 +8,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 
-import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
 import static no.api.freemarker.java8.time.DateTimeTools.createDateTimeFormatter;
 
 public class ZonedDateTimeFormatter extends AbstractFormatter<ZonedDateTime> implements TemplateMethodModelEx {
@@ -23,10 +22,11 @@ public class ZonedDateTimeFormatter extends AbstractFormatter<ZonedDateTime> imp
         final ZoneId targetZoneId = getTargetZoneId(list, getObject().getZone());
 
         if (isDifferentTimeZoneRequested(targetZoneId)) {
-            return getObject().withZoneSameInstant(targetZoneId).format(createDateTimeFormatter(list, 0, ISO_ZONED_DATE_TIME));
+            return getObject().withZoneSameInstant(targetZoneId)
+                              .format(createDateTimeFormatter(list, 0, DefaultFormatters.getZonedDateTimeFormatter()));
         } else {
             return getObject()
-                  .format(createDateTimeFormatter(list, 0, ISO_ZONED_DATE_TIME));
+                  .format(createDateTimeFormatter(list, 0, DefaultFormatters.getZonedDateTimeFormatter()));
         }
     }
 


### PR DESCRIPTION
Added solution for overriding formatter defaults

```java
no.api.freemarker.java8.time.DefaultFormatters.setClockFormatter(DateTimeFormatter.ofPattern('yyyy MM dd HH:mm:ss'))
```